### PR TITLE
Document pre-commit hook setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Unofficial CLI for [Toggl Track](https://toggl.com/) time management, using the 
 cp .env.example .env
 # Edit .env and add your Toggl API token
 npm install
+bash scripts/setup-hooks.sh
 ```
 
 Get your API token from [Toggl Profile](https://track.toggl.com/profile) (scroll to API Token section).


### PR DESCRIPTION
## Summary
- Add `bash scripts/setup-hooks.sh` step to README setup instructions so contributors install the pre-commit hook

Closes #4