### PR TITLE
Fix track command name leaking as description and clean up error output

### DIFF
--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -61,7 +61,14 @@ export function parseArgs(args: string[]): {
 }
 
 export async function entryEdit(args: string[]) {
-  const { id, description, project: projectName, tags: newTags } = parseArgs(args.slice(1));
+  let parsed;
+  try {
+    parsed = parseArgs(args.slice(1));
+  } catch (e) {
+    console.log((e as Error).message);
+    process.exit(1);
+  }
+  const { id, description, project: projectName, tags: newTags } = parsed;
 
   let entry: TimeEntry;
   try {

--- a/src/commands/entry-list.ts
+++ b/src/commands/entry-list.ts
@@ -15,7 +15,13 @@ interface TimeEntry {
 }
 
 export async function entryList(args: string[]) {
-  const date = parseDateArg(args);
+  let date;
+  try {
+    date = parseDateArg(args);
+  } catch (e) {
+    console.log((e as Error).message);
+    process.exit(1);
+  }
   const dayStr = formatDate(date);
   const nextDay = formatDate(new Date(date.getTime() + 86400000));
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -61,7 +61,14 @@ export function parseArgs(args: string[]): {
 }
 
 export async function track(args: string[]) {
-  const { description, project: projectName, tags, at, dur } = parseArgs(args);
+  let parsed;
+  try {
+    parsed = parseArgs(args);
+  } catch (e) {
+    console.log((e as Error).message);
+    process.exit(1);
+  }
+  const { description, project: projectName, tags, at, dur } = parsed;
   const wsId = await config.getWorkspaceId();
 
   let projectId: number | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ switch (command) {
     entryDelete(args);
     break;
   case 'track':
-    track(args);
+    track(args.slice(1));
     break;
   case 'stop':
     stop();


### PR DESCRIPTION
## Summary

Fixes #29

- **Fix `track` command**: pass `args.slice(1)` instead of `args` so the command name `"track"` doesn't leak as the time entry description when no args are provided
- **Clean up error output**: catch argument validation errors in `track()`, `entryEdit()`, and `entryList()` and print a clean message + exit instead of dumping a full stack trace