### PR TITLE
Extract duplicated parse error handling into parseOrExit helper

### DIFF
--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -1,4 +1,5 @@
 import { get, put } from '../api.js';
+import { parseOrExit } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -61,14 +62,12 @@ export function parseArgs(args: string[]): {
 }
 
 export async function entryEdit(args: string[]) {
-  let parsed;
-  try {
-    parsed = parseArgs(args.slice(1));
-  } catch (e) {
-    console.log((e as Error).message);
-    process.exit(1);
-  }
-  const { id, description, project: projectName, tags: newTags } = parsed;
+  const {
+    id,
+    description,
+    project: projectName,
+    tags: newTags,
+  } = parseOrExit(() => parseArgs(args.slice(1)));
 
   let entry: TimeEntry;
   try {

--- a/src/commands/entry-list.ts
+++ b/src/commands/entry-list.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { formatDate, formatTime, formatDuration, parseDateArg } from '../utils.js';
+import { formatDate, formatTime, formatDuration, parseDateArg, parseOrExit } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -15,13 +15,7 @@ interface TimeEntry {
 }
 
 export async function entryList(args: string[]) {
-  let date;
-  try {
-    date = parseDateArg(args);
-  } catch (e) {
-    console.log((e as Error).message);
-    process.exit(1);
-  }
+  const date = parseOrExit(() => parseDateArg(args));
   const dayStr = formatDate(date);
   const nextDay = formatDate(new Date(date.getTime() + 86400000));
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get, post } from '../api.js';
-import { parseDuration, buildStartTime } from '../utils.js';
+import { parseDuration, buildStartTime, parseOrExit } from '../utils.js';
 
 interface Project {
   id: number;
@@ -61,14 +61,7 @@ export function parseArgs(args: string[]): {
 }
 
 export async function track(args: string[]) {
-  let parsed;
-  try {
-    parsed = parseArgs(args);
-  } catch (e) {
-    console.log((e as Error).message);
-    process.exit(1);
-  }
-  const { description, project: projectName, tags, at, dur } = parsed;
+  const { description, project: projectName, tags, at, dur } = parseOrExit(() => parseArgs(args));
   const wsId = await config.getWorkspaceId();
 
   let projectId: number | null = null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,12 @@
+export function parseOrExit<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
+}
+
 export function formatDuration(seconds: number): string {
   if (seconds < 0) {
     seconds = Math.floor(Date.now() / 1000) + seconds;

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -6,6 +6,7 @@ import {
   formatTime,
   buildStartTime,
   parseDateArg,
+  parseOrExit,
 } from '../src/utils.js';
 
 describe('formatDuration', () => {
@@ -127,5 +128,30 @@ describe('parseDateArg', () => {
 
   it('throws on invalid date', () => {
     expect(() => parseDateArg(['-d', 'not-a-date'])).toThrow('Invalid date');
+  });
+});
+
+describe('parseOrExit', () => {
+  it('returns the value on success', () => {
+    const result = parseOrExit(() => 42);
+    expect(result).toBe(42);
+  });
+
+  it('writes error to stderr and exits on throw', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    expect(() =>
+      parseOrExit(() => {
+        throw new Error('bad input');
+      })
+    ).toThrow('process.exit');
+    expect(errorSpy).toHaveBeenCalledWith('bad input');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Closes #33

Extracts a generic `parseOrExit<T>` helper into `utils.ts` and uses it in the 3 commands that had duplicated `try/catch` + `process.exit(1)` patterns around argument parsing:

- `track.ts`
- `entry-edit.ts`
- `entry-list.ts`

Also switches from `console.log` to `console.error` for parse error output.

All 52 tests pass.