### PR TITLE
Standardize arg-slicing convention across commands (#31)

### DIFF
--- a/src/commands/entry-delete.ts
+++ b/src/commands/entry-delete.ts
@@ -10,7 +10,7 @@ interface TimeEntry {
 }
 
 export async function entryDelete(args: string[]) {
-  const id = args.slice(1).find((a) => !a.startsWith('-'));
+  const id = args.find((a) => !a.startsWith('-'));
   if (!id) {
     console.log('Usage: tsx src/index.ts entry-delete <entry_id>');
     process.exit(1);

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -62,12 +62,7 @@ export function parseArgs(args: string[]): {
 }
 
 export async function entryEdit(args: string[]) {
-  const {
-    id,
-    description,
-    project: projectName,
-    tags: newTags,
-  } = parseOrExit(() => parseArgs(args.slice(1)));
+  const { id, description, project: projectName, tags: newTags } = parseOrExit(() => parseArgs(args));
 
   let entry: TimeEntry;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ async function me() {
 }
 
 const command = process.argv[2];
-const args = process.argv.slice(2);
+const args = process.argv.slice(3);
 
 switch (command) {
   case 'me':
@@ -37,7 +37,7 @@ switch (command) {
     entryDelete(args);
     break;
   case 'track':
-    track(args.slice(1));
+    track(args);
     break;
   case 'stop':
     stop();

--- a/tests/entry-delete.test.ts
+++ b/tests/entry-delete.test.ts
@@ -31,7 +31,7 @@ describe('entryDelete command', () => {
     });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await expect(entryDelete(['entry-delete'])).rejects.toThrow('exit');
+    await expect(entryDelete([])).rejects.toThrow('exit');
 
     expect(logSpy).toHaveBeenCalledWith('Usage: tsx src/index.ts entry-delete <entry_id>');
     expect(exitSpy).toHaveBeenCalledWith(1);
@@ -43,7 +43,7 @@ describe('entryDelete command', () => {
     mockedGet.mockRejectedValue(new Error('404'));
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await entryDelete(['entry-delete', '999']);
+    await entryDelete(['999']);
 
     expect(logSpy).toHaveBeenCalledWith('Entry 999 not found.');
     logSpy.mockRestore();
@@ -54,7 +54,7 @@ describe('entryDelete command', () => {
     mockedDel.mockResolvedValue(undefined);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await entryDelete(['entry-delete', '100']);
+    await entryDelete(['100']);
 
     expect(mockedDel).toHaveBeenCalledWith('/workspaces/123/time_entries/100');
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Deleted: Test entry'));
@@ -66,7 +66,7 @@ describe('entryDelete command', () => {
     mockedDel.mockRejectedValue(new Error('Toggl API 400: Bad Request'));
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await entryDelete(['entry-delete', '100']);
+    await entryDelete(['100']);
 
     expect(logSpy).toHaveBeenCalledWith('Entry 100 not found or already deleted.');
     logSpy.mockRestore();
@@ -77,7 +77,7 @@ describe('entryDelete command', () => {
     mockedDel.mockRejectedValue(new Error('Toggl API 404: Not Found'));
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await entryDelete(['entry-delete', '100']);
+    await entryDelete(['100']);
 
     expect(logSpy).toHaveBeenCalledWith('Entry 100 not found or already deleted.');
     logSpy.mockRestore();
@@ -87,7 +87,7 @@ describe('entryDelete command', () => {
     mockedGet.mockResolvedValue({ ...baseEntry });
     mockedDel.mockRejectedValue(new Error('Toggl API 500: Server Error'));
 
-    await expect(entryDelete(['entry-delete', '100'])).rejects.toThrow('500');
+    await expect(entryDelete(['100'])).rejects.toThrow('500');
   });
 
   it('shows fallback for entry without description or project', async () => {
@@ -99,7 +99,7 @@ describe('entryDelete command', () => {
     mockedDel.mockResolvedValue(undefined);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await entryDelete(['entry-delete', '100']);
+    await entryDelete(['100']);
 
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('(no description)'));
     expect(logSpy).toHaveBeenCalledWith(expect.not.stringContaining('['));

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -36,7 +36,7 @@ describe('entryEdit command', () => {
       description: 'Updated',
     });
 
-    await entryEdit(['entry-edit', '100', '-d', 'Updated']);
+    await entryEdit(['100', '-d', 'Updated']);
 
     expect(mockedPut).toHaveBeenCalledWith(
       '/workspaces/123/time_entries/100',
@@ -59,7 +59,7 @@ describe('entryEdit command', () => {
       project_name: 'NewProject',
     });
 
-    await entryEdit(['entry-edit', '100', '-p', 'NewProject']);
+    await entryEdit(['100', '-p', 'NewProject']);
 
     expect(mockedPut).toHaveBeenCalledWith(
       '/workspaces/123/time_entries/100',
@@ -76,7 +76,7 @@ describe('entryEdit command', () => {
       tags: ['review', 'bug'],
     });
 
-    await entryEdit(['entry-edit', '100', '-t', 'review,bug']);
+    await entryEdit(['100', '-t', 'review,bug']);
 
     expect(mockedPut).toHaveBeenCalledWith(
       '/workspaces/123/time_entries/100',
@@ -90,7 +90,7 @@ describe('entryEdit command', () => {
     mockedGet.mockRejectedValue(new Error('404'));
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    await entryEdit(['entry-edit', '999', '-d', 'Test']);
+    await entryEdit(['999', '-d', 'Test']);
 
     expect(logSpy).toHaveBeenCalledWith('Entry 999 not found.');
     logSpy.mockRestore();
@@ -105,7 +105,7 @@ describe('entryEdit command', () => {
       throw new Error('exit');
     });
 
-    await expect(entryEdit(['entry-edit', '100', '-p', 'Missing'])).rejects.toThrow('exit');
+    await expect(entryEdit(['100', '-p', 'Missing'])).rejects.toThrow('exit');
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();


### PR DESCRIPTION
## Summary

- Always slice args in `src/index.ts` (`process.argv.slice(3)`) so commands never receive the command name
- Remove internal `args.slice(1)` from `entry-delete` and `entry-edit` command functions
- Update tests to pass pre-sliced args (without command name in arrays)

Closes #31