### PR TITLE
Use stderr for error messages

### DIFF
--- a/src/commands/entry-delete.ts
+++ b/src/commands/entry-delete.ts
@@ -12,7 +12,7 @@ interface TimeEntry {
 export async function entryDelete(args: string[]) {
   const id = args.find((a) => !a.startsWith('-'));
   if (!id) {
-    console.log('Usage: tsx src/index.ts entry-delete <entry_id>');
+    console.error('Usage: tsx src/index.ts entry-delete <entry_id>');
     process.exit(1);
   }
 
@@ -20,7 +20,7 @@ export async function entryDelete(args: string[]) {
   try {
     entry = await get<TimeEntry>(`/me/time_entries/${id}`);
   } catch {
-    console.log(`Entry ${id} not found.`);
+    console.error(`Entry ${id} not found.`);
     return;
   }
 
@@ -42,7 +42,7 @@ export async function entryDelete(args: string[]) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes('400') || msg.includes('404')) {
-      console.log(`Entry ${id} not found or already deleted.`);
+      console.error(`Entry ${id} not found or already deleted.`);
       return;
     }
     throw e;

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -68,7 +68,7 @@ export async function entryEdit(args: string[]) {
   try {
     entry = await get<TimeEntry>(`/me/time_entries/${id}`);
   } catch {
-    console.log(`Entry ${id} not found.`);
+    console.error(`Entry ${id} not found.`);
     return;
   }
 
@@ -79,14 +79,14 @@ export async function entryEdit(args: string[]) {
     const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
     const matches = projects.filter((p) => p.name.toLowerCase() === projectName.toLowerCase());
     if (matches.length === 0) {
-      console.log(
+      console.error(
         `Project "${projectName}" not found. Use "npm run project-list" to list available projects.`
       );
       process.exit(1);
     }
     if (matches.length > 1) {
-      console.log(`Multiple projects match "${projectName}":`);
-      matches.forEach((p) => console.log(`  ${p.id}  ${p.name}`));
+      console.error(`Multiple projects match "${projectName}":`);
+      matches.forEach((p) => console.error(`  ${p.id}  ${p.name}`));
       process.exit(1);
     }
     projectId = matches[0].id;

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -15,7 +15,7 @@ export async function stop() {
   const current = await get<TimeEntry | null>('/me/time_entries/current');
 
   if (!current) {
-    console.log('No running timer.');
+    console.error('No running timer.');
     return;
   }
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -69,14 +69,14 @@ export async function track(args: string[]) {
     const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
     const matches = projects.filter((p) => p.name.toLowerCase() === projectName.toLowerCase());
     if (matches.length === 0) {
-      console.log(
+      console.error(
         `Project "${projectName}" not found. Use "npm run project-list" to list available projects.`
       );
       process.exit(1);
     }
     if (matches.length > 1) {
-      console.log(`Multiple projects match "${projectName}":`);
-      matches.forEach((p) => console.log(`  ${p.id}  ${p.name}`));
+      console.error(`Multiple projects match "${projectName}":`);
+      matches.forEach((p) => console.error(`  ${p.id}  ${p.name}`));
       process.exit(1);
     }
     projectId = matches[0].id;
@@ -84,7 +84,7 @@ export async function track(args: string[]) {
 
   const isTimed = at !== null && dur !== null;
   if ((at !== null) !== (dur !== null)) {
-    console.log('Both --at and --dur must be provided together, or neither for a running timer.');
+    console.error('Both --at and --dur must be provided together, or neither for a running timer.');
     process.exit(1);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,8 @@ switch (command) {
     entryEdit(args);
     break;
   default:
-    console.log('Usage: tsx src/index.ts <command>');
-    console.log(
+    console.error('Usage: tsx src/index.ts <command>');
+    console.error(
       'Commands: me, entry-list [-d DATE], project-list, entry-delete <entry_id>, track, stop, tag-list, entry-edit'
     );
 }

--- a/tests/entry-delete.test.ts
+++ b/tests/entry-delete.test.ts
@@ -29,7 +29,7 @@ describe('entryDelete command', () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(entryDelete([])).rejects.toThrow('exit');
 
@@ -41,7 +41,7 @@ describe('entryDelete command', () => {
 
   it('prints not found when GET fails', async () => {
     mockedGet.mockRejectedValue(new Error('404'));
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await entryDelete(['999']);
 
@@ -64,7 +64,7 @@ describe('entryDelete command', () => {
   it('handles 400 error during delete', async () => {
     mockedGet.mockResolvedValue({ ...baseEntry });
     mockedDel.mockRejectedValue(new Error('Toggl API 400: Bad Request'));
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await entryDelete(['100']);
 
@@ -75,7 +75,7 @@ describe('entryDelete command', () => {
   it('handles 404 error during delete', async () => {
     mockedGet.mockResolvedValue({ ...baseEntry });
     mockedDel.mockRejectedValue(new Error('Toggl API 404: Not Found'));
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await entryDelete(['100']);
 

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -89,7 +89,7 @@ describe('entryEdit command', () => {
   it('prints not found when entry does not exist', async () => {
     mockedGet.mockRejectedValue(new Error('404'));
 
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     await entryEdit(['999', '-d', 'Test']);
 
     expect(logSpy).toHaveBeenCalledWith('Entry 999 not found.');


### PR DESCRIPTION
## Summary

Closes #32

- Changed all error/diagnostic `console.log` calls to `console.error` across 5 files (11 instances total) so that error messages write to stderr instead of stdout, following Unix convention.
- Normal output (success messages, list commands) remains on stdout via `console.log`.