### PR TITLE
Implement distributed config and auth command (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-TOGGL_API_TOKEN=your_token_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ CLI tool for Toggl Track time management. TypeScript, runs via `tsx`.
 
 - Node 22 + TypeScript (strict mode, ES modules)
 - `tsx` for running TS directly
-- `dotenv` for env config
+- Config via `~/.config/tgt/config.env` (macOS/Linux) or `%APPDATA%\tgt\config.env` (Windows)
 - No framework — plain `fetch` for HTTP, no CLI parser yet
 
 ## Commands
@@ -16,6 +16,8 @@ CLI tool for Toggl Track time management. TypeScript, runs via `tsx`.
 See README.md for available commands and usage.
 
 ## Guidelines
+
+- **Never commit directly to `main`** — always create a feature branch first
 
 This file describes common mistakes and confusion points that an agent may encounter as
 they work on this project. If you ever encounter something that surprises you or

--- a/README.md
+++ b/README.md
@@ -5,26 +5,30 @@ Unofficial CLI for [Toggl Track](https://toggl.com/) time management, using the 
 ## Setup
 
 ```bash
-cp .env.example .env
-# Edit .env and add your Toggl API token
 npm install
 bash scripts/setup-hooks.sh
+tgt auth <your-api-token>
 ```
 
 Get your API token from [Toggl Profile](https://track.toggl.com/profile) (scroll to API Token section).
 
+Config is saved to `~/.config/tgt/config.env` (macOS/Linux) or
+`%APPDATA%\tgt\config.env` (Windows). You can also set `TOGGL_API_TOKEN`
+as an environment variable, which takes priority over the config file.
+
 ## Commands
 
-| Command                                        | Description                 | Docs                                         |
-| ---------------------------------------------- | --------------------------- | -------------------------------------------- |
-| `npm run me`                                   | Verify authentication       | [docs/me.md](docs/me.md)                     |
-| `npm run entry-list`                           | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
-| `npm run project-list`                         | List workspace projects     | [docs/project-list.md](docs/project-list.md) |
-| `npm run entry-delete -- <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |
-| `npm run track -- "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
-| `npm run stop`                                 | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
-| `npm run tag-list`                             | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)         |
-| `npm run entry-edit -- <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
+| Command                                 | Description                 | Docs                                         |
+| --------------------------------------- | --------------------------- | -------------------------------------------- |
+| `tgt auth <token>`                      | Save API token              |                                              |
+| `tgt me`                                | Verify authentication       | [docs/me.md](docs/me.md)                     |
+| `tgt entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
+| `tgt project-list`                      | List workspace projects     | [docs/project-list.md](docs/project-list.md) |
+| `tgt entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |
+| `tgt track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
+| `tgt stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
+| `tgt tag-list`                          | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)         |
+| `tgt entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
 
 ## Environment Variables
 
@@ -37,10 +41,12 @@ Get your API token from [Toggl Profile](https://track.toggl.com/profile) (scroll
 
 ```text
 src/
-  config.ts           # Env config + workspace resolution
+  paths.ts            # Cross-platform config/cache directory resolution
+  config.ts           # Config loading (env vars > config file)
   api.ts              # HTTP client with auth
   index.ts            # CLI entry point
   commands/
+    auth.ts           # Save API token (tgt auth)
     entry-list.ts     # List time entries + totals
     project-list.ts   # List workspace projects
     entry-delete.ts   # Delete a time entry

--- a/docs/distributed-config.md
+++ b/docs/distributed-config.md
@@ -14,12 +14,20 @@ Support both environment variables and a config file, with env vars taking prior
 
 1. **Environment variables** (`TOGGL_API_TOKEN`, `TOGGL_WORKSPACE_ID`)
    — for CI/CD, scripting, `~/.zshrc`
-2. **Config file** (`~/.tgt.env`) — for interactive daily use,
-   same dotenv format
+2. **Config file** — for interactive daily use, same dotenv format
 
-### Config File Location
+### Paths (cross-platform)
 
-`~/.tgt.env`
+Resolved by `src/paths.ts` — no external dependencies.
+
+|                 | Config                     | Cache                       |
+| --------------- | -------------------------- | --------------------------- |
+| **macOS/Linux** | `~/.config/tgt/config.env` | `~/.cache/tgt/`             |
+| **Windows**     | `%APPDATA%\tgt\config.env` | `%LOCALAPPDATA%\tgt\Cache\` |
+
+### Config File
+
+Example (`~/.config/tgt/config.env`):
 
 ```env
 TOGGL_API_TOKEN=your_token_here
@@ -36,21 +44,25 @@ $ tgt
   Get your token at https://track.toggl.com/profile
 
 $ tgt auth my_api_token_here
-  Config saved to ~/.tgt.env
+  Config saved to ~/.config/tgt/config.env
+  Authenticated as Stefano Locati (user@domain.com)
 
 $ tgt me
-  ✓ Authenticated as Stefano Locati (user@domain.com)
+  Authenticated as: Stefano Locati (user@domain.com)
+  Default workspace: 123456
 ```
 
-### Changes Needed
+### Implementation
 
-- `config.ts`: check env vars first, then fall back to `~/.tgt.env`
-- New `auth` command: validate token via API, save to `~/.tgt.env`
-- Remove `.env` dependency on project directory
+- `src/paths.ts`: cross-platform config/cache directory resolution
+- `config.ts`: check env vars first, then fall back to config file via `paths.ts`
+- `src/commands/auth.ts`: validate token via API (`getWithToken`), save to config file
+- `api.ts`: `getWithToken()` for making API calls with an explicit token (needed by auth before config exists)
+- Remove `dotenv` dependency — config file is parsed manually
 - Keep `.env.example` in repo for contributors who clone
 
 ### Notes
 
 - Config file is plain text — avoid storing anything beyond the API token
-- `tgt auth` without a token could prompt interactively (see interactive-mode.md)
-- Consider warning if config file has overly permissive permissions (e.g. `chmod 600`)
+- `tgt auth` warns if config file has overly permissive permissions (suggests `chmod 600` on macOS/Linux)
+- Config file is created with mode `0o600`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "toggl-pilot",
       "version": "1.0.0",
-      "dependencies": {
-        "dotenv": "^17.4.2"
-      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
@@ -1690,18 +1687,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "test:watch": "vitest",
     "pre-commit": "tsx scripts/pre-commit.ts"
   },
-  "dependencies": {
-    "dotenv": "^17.4.2"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/index.ts",
-    "track": "tsx src/index.ts track",
+    "auth": "tsx src/index.ts auth",
     "me": "tsx src/index.ts me",
     "entry-list": "tsx src/index.ts entry-list",
     "project-list": "tsx src/index.ts project-list",

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,14 +4,7 @@ const BASE_URL = 'https://api.track.toggl.com/api/v9';
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const url = `${BASE_URL}${path}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Basic ${btoa(`${config.apiToken}:api_token`)}`,
-      ...options.headers,
-    },
-  });
+  const res = await fetch(url, options);
 
   if (!res.ok) {
     const body = await res.text().catch(() => '');
@@ -24,8 +17,29 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   return JSON.parse(text);
 }
 
+function authHeaders(token: string): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Basic ${btoa(`${token}:api_token`)}`,
+  };
+}
+
+async function requestWithConfig<T>(path: string, options: RequestInit = {}): Promise<T> {
+  return request<T>(path, {
+    ...options,
+    headers: {
+      ...authHeaders(config.apiToken),
+      ...options.headers,
+    },
+  });
+}
+
 export function get<T>(path: string): Promise<T> {
-  return request<T>(path);
+  return requestWithConfig<T>(path);
+}
+
+export async function getWithToken<T>(path: string, token: string): Promise<T> {
+  return request<T>(path, { headers: authHeaders(token) });
 }
 
 export function post<T>(path: string, body: unknown): Promise<T> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -43,13 +43,13 @@ export async function getWithToken<T>(path: string, token: string): Promise<T> {
 }
 
 export function post<T>(path: string, body: unknown): Promise<T> {
-  return request<T>(path, { method: 'POST', body: JSON.stringify(body) });
+  return requestWithConfig<T>(path, { method: 'POST', body: JSON.stringify(body) });
 }
 
 export function del<T>(path: string): Promise<T> {
-  return request<T>(path, { method: 'DELETE' });
+  return requestWithConfig<T>(path, { method: 'DELETE' });
 }
 
 export function put<T>(path: string, body: unknown): Promise<T> {
-  return request<T>(path, { method: 'PUT', body: JSON.stringify(body) });
+  return requestWithConfig<T>(path, { method: 'PUT', body: JSON.stringify(body) });
 }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,0 +1,40 @@
+import { writeFileSync, statSync } from 'node:fs';
+import { getWithToken } from '../api.js';
+import { getConfigFile } from '../paths.js';
+
+interface Me {
+  fullname: string;
+  email: string;
+}
+
+export async function auth(args: string[]) {
+  const token = args[0];
+  if (!token) {
+    console.error('Usage: tgt auth <api-token>');
+    console.error('Get your token at https://track.toggl.com/profile');
+    process.exit(1);
+  }
+
+  try {
+    const user = await getWithToken<Me>('/me', token);
+    const file = getConfigFile();
+    writeFileSync(file, `TOGGL_API_TOKEN=${token}\n`, { mode: 0o600 });
+    console.log(`Config saved to ${file}`);
+    console.log(`Authenticated as ${user.fullname} (${user.email})`);
+
+    try {
+      const st = statSync(file);
+      const mode = st.mode & 0o777;
+      if (process.platform !== 'win32' && mode !== 0o600) {
+        console.warn(
+          `Warning: config file permissions are ${mode.toString(8)}. Consider running: chmod 600 ${file}`
+        );
+      }
+    } catch {
+      // skip permission check
+    }
+  } catch (e) {
+    console.error(`Authentication failed: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,57 @@
-import 'dotenv/config';
+import { existsSync, readFileSync } from 'node:fs';
 import { get } from './api.js';
+import { getConfigFile } from './paths.js';
+
+class ConfigNotFoundError extends Error {
+  constructor() {
+    super(
+      'No config found. Run: tgt auth <api-token>\n' +
+        'Or set TOGGL_API_TOKEN in your environment.\n' +
+        'Get your token at https://track.toggl.com/profile'
+    );
+    this.name = 'ConfigNotFoundError';
+  }
+}
+
+function loadConfigFile(): Record<string, string> {
+  const file = getConfigFile();
+  if (!existsSync(file)) return {};
+  const content = readFileSync(file, 'utf-8');
+  const result: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed.slice(eq + 1).trim();
+    result[key] = val;
+  }
+  return result;
+}
+
+function getVar(name: string): string | undefined {
+  if (process.env[name]) return process.env[name];
+  return loadConfigFile()[name];
+}
+
+export function hasConfig(): boolean {
+  const token = getVar('TOGGL_API_TOKEN');
+  return !!token && token !== 'your_token_here';
+}
 
 export const config = {
   get apiToken() {
-    const token = process.env.TOGGL_API_TOKEN;
+    const token = getVar('TOGGL_API_TOKEN');
     if (!token || token === 'your_token_here') {
-      throw new Error('TOGGL_API_TOKEN not set. Copy .env.example to .env and add your token.');
+      throw new ConfigNotFoundError();
     }
     return token;
   },
   _workspaceId: null as number | null,
   async getWorkspaceId(): Promise<number> {
     if (this._workspaceId) return this._workspaceId;
-    const envId = process.env.TOGGL_WORKSPACE_ID;
+    const envId = getVar('TOGGL_WORKSPACE_ID');
     if (envId) {
       this._workspaceId = Number(envId);
       return this._workspaceId;
@@ -22,3 +61,5 @@ export const config = {
     return this._workspaceId;
   },
 };
+
+export { ConfigNotFoundError };

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,10 @@ class ConfigNotFoundError extends Error {
   }
 }
 
+let cachedConfig: Record<string, string> | null = null;
+
 function loadConfigFile(): Record<string, string> {
+  if (cachedConfig) return cachedConfig;
   const file = getConfigFile();
   if (!existsSync(file)) return {};
   const content = readFileSync(file, 'utf-8');
@@ -24,9 +27,13 @@ function loadConfigFile(): Record<string, string> {
     const eq = trimmed.indexOf('=');
     if (eq === -1) continue;
     const key = trimmed.slice(0, eq).trim();
-    const val = trimmed.slice(eq + 1).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
     result[key] = val;
   }
+  cachedConfig = result;
   return result;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { get } from './api.js';
+import { hasConfig, ConfigNotFoundError } from './config.js';
 import { entryList } from './commands/entry-list.js';
 import { projectList } from './commands/project-list.js';
 import { entryDelete } from './commands/entry-delete.js';
@@ -6,6 +7,7 @@ import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
 import { entryEdit } from './commands/entry-edit.js';
+import { auth } from './commands/auth.js';
 
 interface Me {
   id: number;
@@ -23,34 +25,41 @@ async function me() {
 const command = process.argv[2];
 const args = process.argv.slice(3);
 
-switch (command) {
-  case 'me':
-    me();
-    break;
-  case 'entry-list':
-    entryList(args);
-    break;
-  case 'project-list':
-    projectList();
-    break;
-  case 'entry-delete':
-    entryDelete(args);
-    break;
-  case 'track':
-    track(args);
-    break;
-  case 'stop':
-    stop();
-    break;
-  case 'tag-list':
-    tagList();
-    break;
-  case 'entry-edit':
-    entryEdit(args);
-    break;
-  default:
-    console.error('Usage: tsx src/index.ts <command>');
-    console.error(
-      'Commands: me, entry-list [-d DATE], project-list, entry-delete <entry_id>, track, stop, tag-list, entry-edit'
-    );
+if (command === 'auth') {
+  auth(args);
+} else if (!hasConfig()) {
+  console.error(new ConfigNotFoundError().message);
+  process.exit(1);
+} else {
+  switch (command) {
+    case 'me':
+      me();
+      break;
+    case 'entry-list':
+      entryList(args);
+      break;
+    case 'project-list':
+      projectList();
+      break;
+    case 'entry-delete':
+      entryDelete(args);
+      break;
+    case 'track':
+      track(args);
+      break;
+    case 'stop':
+      stop();
+      break;
+    case 'tag-list':
+      tagList();
+      break;
+    case 'entry-edit':
+      entryEdit(args);
+      break;
+    default:
+      console.error('Usage: tgt <command>');
+      console.error(
+        'Commands: auth, me, entry-list [-d DATE], project-list, entry-delete <entry_id>, track, stop, tag-list, entry-edit'
+      );
+  }
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,29 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const APP_NAME = 'tgt';
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
+}
+
+export function getConfigDir(): string {
+  const dir = isWindows()
+    ? join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), APP_NAME)
+    : join(homedir(), '.config', APP_NAME);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function getConfigFile(): string {
+  return join(getConfigDir(), 'config.env');
+}
+
+export function getCacheDir(): string {
+  const dir = isWindows()
+    ? join(process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'), APP_NAME, 'Cache')
+    : join(homedir(), '.cache', APP_NAME);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}


### PR DESCRIPTION
## Summary

- Add `tgt auth <token>` command that validates the token via API and saves it to a cross-platform config file
- Replace `dotenv` with manual config file parsing — env vars take priority, then falls back to config file
- Add `src/paths.ts` for cross-platform config/cache directory resolution (XDG on macOS/Linux, APPDATA on Windows)
- Show clear setup instructions when no config is found
- Update README, docs, and AGENTS.md

## Config Paths

| | Config | Cache |
|---|---|---|
| **macOS/Linux** | `~/.config/tgt/config.env` | `~/.cache/tgt/` |
| **Windows** | `%APPDATA%\tgt\config.env` | `%LOCALAPPDATA%\tgt\Cache\` |

Closes #18