### PR TITLE
Restore missing track npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "auth": "tsx src/index.ts auth",
+    "track": "tsx src/index.ts track",
     "me": "tsx src/index.ts me",
     "entry-list": "tsx src/index.ts entry-list",
     "project-list": "tsx src/index.ts project-list",


### PR DESCRIPTION
## Summary
- Add back the `track` npm script that was accidentally dropped during the noun-first rename in #25