### PR TITLE
Note that squash merges require force delete (-D)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,9 @@ See README.md for available commands and usage.
 ## Guidelines
 
 - **Never commit directly to `main`** — always create a feature branch first
-- **After merging a PR**, switch to `main`, run `git pull && git fetch --prune`, then delete the local branch (`git branch -d <branch>`)
+- **After merging a PR**, switch to `main`, run `git pull && git fetch --prune`,
+  then delete the local branch (`git branch -D <branch>` — use `-D` since squash
+  merges require force delete)
 
 This file describes common mistakes and confusion points that an agent may encounter as
 they work on this project. If you ever encounter something that surprises you or


### PR DESCRIPTION
AGENTS.md already had the post-merge cleanup guideline but used `-d` which fails with squash merges. Updated to use `-D` with an explanation.