### PR TITLE
chore: set up version management and workflow (#42)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,21 @@ Examples:
 - `fix/typo-in-help-text`
 - `chore/update-deps`
 
+## PR Title Convention
+
+Prefix PR titles with the type of change using conventional commit format:
+
+- `feat:` — new feature or enhancement
+- `fix:` — bug fix
+- `chore:` — maintenance, tooling, dependency updates
+- `docs:` — documentation changes
+- `refactor:` — code restructuring without behavior change
+- `test:` — adding or updating tests
+
+This matters because CI will use `feat:` and `fix:` PRs for auto-generated release notes, while other types are excluded.
+
+Example PR title: `feat: set up version management and workflow (#42)`
+
 ## API Quota (Free Plan)
 
 30 requests per hour, per user, per organization. When developing/testing, be mindful

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ as an environment variable, which takes priority over the config file.
 | Command                                 | Description                 | Docs                                         |
 | --------------------------------------- | --------------------------- | -------------------------------------------- |
 | `tgt auth <token>`                      | Save API token              |                                              |
+| `tgt version`                           | Show CLI version            |                                              |
 | `tgt me`                                | Verify authentication       | [docs/me.md](docs/me.md)                     |
 | `tgt entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
 | `tgt project-list`                      | List workspace projects     | [docs/project-list.md](docs/project-list.md) |
@@ -37,6 +38,34 @@ as an environment variable, which takes priority over the config file.
 | `TOGGL_API_TOKEN`    | Yes      | Your Toggl Track API token         |
 | `TOGGL_WORKSPACE_ID` | No       | Defaults to your primary workspace |
 
+## Releasing
+
+### PR Title Convention
+
+Prefix PR titles with the type of change:
+
+- `feat:` — new feature or enhancement (included in release notes)
+- `fix:` — bug fix (included in release notes)
+- `chore:`, `docs:`, `refactor:`, `test:` — excluded from release notes
+
+### Version Bump
+
+```bash
+npm version patch   # 0.1.0 → 0.1.1 (bug fixes)
+npm version minor   # 0.1.0 → 0.2.0 (new features)
+npm version major   # 0.1.0 → 1.0.0 (breaking changes)
+```
+
+This bumps `package.json`, creates a git commit and tag (e.g. `v0.2.0`). Then push:
+
+```bash
+git push --follow-tags
+```
+
+### Release Notes
+
+Release notes are auto-generated from `feat:` and `fix:` commits between tags. This will be set up in CI when a `v*` tag is pushed.
+
 ## Architecture
 
 ```text
@@ -47,6 +76,7 @@ src/
   index.ts            # CLI entry point
   commands/
     auth.ts           # Save API token (tgt auth)
+    version.ts        # Show CLI version (tgt version)
     entry-list.ts     # List time entries + totals
     project-list.ts   # List workspace projects
     entry-delete.ts   # Delete a time entry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "toggl-pilot",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toggl-pilot",
-      "version": "1.0.0",
+      "version": "0.1.0",
+      "bin": {
+        "tgt": "dist/index.js"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toggl-pilot",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "bin": {
@@ -13,6 +13,7 @@
     "start": "tsx src/index.ts",
     "build": "tsup",
     "auth": "tsx src/index.ts auth",
+    "version": "tsx src/index.ts version",
     "track": "tsx src/index.ts track",
     "me": "tsx src/index.ts me",
     "entry-list": "tsx src/index.ts entry-list",

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,11 +1,22 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { join, dirname } from 'node:path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'));
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getVersion(): string {
+  if (process.env.npm_package_version) return process.env.npm_package_version;
+  const candidates = [join(__dirname, '..', '..', 'package.json'), join(__dirname, '..', 'package.json')];
+  for (const p of candidates) {
+    try {
+      return JSON.parse(readFileSync(p, 'utf-8')).version;
+    } catch {
+      continue;
+    }
+  }
+  return 'unknown';
+}
 
 export function version() {
-  console.log(`tgt v${pkg.version}`);
+  console.log(`tgt v${getVersion()}`);
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'));
+
+export function version() {
+  console.log(`tgt v${pkg.version}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
 import { entryEdit } from './commands/entry-edit.js';
 import { auth } from './commands/auth.js';
+import { version } from './commands/version.js';
 
 interface Me {
   id: number;
@@ -28,6 +29,8 @@ const args = process.argv.slice(3);
 
 if (command === 'auth') {
   auth(args);
+} else if (command === 'version') {
+  version();
 } else if (!hasConfig()) {
   console.error(new ConfigNotFoundError().message);
   process.exit(1);
@@ -60,7 +63,7 @@ if (command === 'auth') {
     default:
       console.error('Usage: tgt <command>');
       console.error(
-        'Commands: auth, me, entry-list [-d DATE], project-list, entry-delete <entry_id>, track, stop, tag-list, entry-edit'
+        'Commands: auth, version, me, entry-list [-d DATE], project-list, entry-delete <entry_id>, track, stop, tag-list, entry-edit'
       );
   }
 }


### PR DESCRIPTION
## Summary

- Set initial version to `0.1.0` in `package.json`
- Add `tgt version` command to display the current CLI version
- Add `npm run version` convenience script
- Document versioning workflow (bumping, tagging, pushing) in README
- Document PR title convention (`feat:`, `fix:`, `chore:`, etc.) in both README and AGENTS.md

## Future work

- CI workflow to auto-generate GitHub Releases from `feat:`/`fix:` commits on `v*` tag push (separate issue)

Closes #42