### PR TITLE
chore: set up npm publish configuration (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 # toggl-pilot
 
+[![npm version](https://img.shields.io/npm/v/toggl-pilot.svg)](https://www.npmjs.com/package/toggl-pilot) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Unofficial CLI for [Toggl Track](https://toggl.com/) time management, using the [Toggl Track API v9](https://developers.track.toggl.com/docs/).
 
-## Setup
+Track your time from the terminal — start/stop timers, log entries, list projects and tags, edit and delete entries.
+
+## Install
 
 ```bash
-npm install
-bash scripts/setup-hooks.sh
+npm install -g toggl-pilot
+```
+
+## Quick Start
+
+```bash
 tgt auth <your-api-token>
+tgt me
+tgt track "Working on feature" -p "My Project"
+tgt stop
+tgt entry-list
 ```
 
 Get your API token from [Toggl Profile](https://track.toggl.com/profile) (scroll to API Token section).
-
-Config is saved to `~/.config/tgt/config.env` (macOS/Linux) or
-`%APPDATA%\tgt\config.env` (Windows). You can also set `TOGGL_API_TOKEN`
-as an environment variable, which takes priority over the config file.
 
 ## Commands
 
@@ -30,6 +38,12 @@ as an environment variable, which takes priority over the config file.
 | `tgt stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
 | `tgt tag-list`                          | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)         |
 | `tgt entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
+
+## Configuration
+
+Config is saved to `~/.config/tgt/config.env` (macOS/Linux) or
+`%APPDATA%\tgt\config.env` (Windows). You can also set `TOGGL_API_TOKEN`
+as an environment variable, which takes priority over the config file.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ tgt stop
 tgt entry-list
 ```
 
-Get your API token from [Toggl Profile](https://track.toggl.com/profile) (scroll to API Token section).
+Get your API token from your [Toggl Profile](https://track.toggl.com/profile) (scroll to API Token section).
+
+Running `tgt auth` saves your token so you don't need to pass it every time.
+You can also set the `TOGGL_API_TOKEN` environment variable, which takes
+priority over the saved config.
 
 ## Commands
 
@@ -42,63 +46,12 @@ Get your API token from [Toggl Profile](https://track.toggl.com/profile) (scroll
 ## Configuration
 
 Config is saved to `~/.config/tgt/config.env` (macOS/Linux) or
-`%APPDATA%\tgt\config.env` (Windows). You can also set `TOGGL_API_TOKEN`
-as an environment variable, which takes priority over the config file.
-
-## Environment Variables
+`%APPDATA%\tgt\config.env` (Windows).
 
 | Variable             | Required | Description                        |
 | -------------------- | -------- | ---------------------------------- |
 | `TOGGL_API_TOKEN`    | Yes      | Your Toggl Track API token         |
 | `TOGGL_WORKSPACE_ID` | No       | Defaults to your primary workspace |
-
-## Releasing
-
-### PR Title Convention
-
-Prefix PR titles with the type of change:
-
-- `feat:` — new feature or enhancement (included in release notes)
-- `fix:` — bug fix (included in release notes)
-- `chore:`, `docs:`, `refactor:`, `test:` — excluded from release notes
-
-### Version Bump
-
-```bash
-npm version patch   # 0.1.0 → 0.1.1 (bug fixes)
-npm version minor   # 0.1.0 → 0.2.0 (new features)
-npm version major   # 0.1.0 → 1.0.0 (breaking changes)
-```
-
-This bumps `package.json`, creates a git commit and tag (e.g. `v0.2.0`). Then push:
-
-```bash
-git push --follow-tags
-```
-
-### Release Notes
-
-Release notes are auto-generated from `feat:` and `fix:` commits between tags. This will be set up in CI when a `v*` tag is pushed.
-
-## Architecture
-
-```text
-src/
-  paths.ts            # Cross-platform config/cache directory resolution
-  config.ts           # Config loading (env vars > config file)
-  api.ts              # HTTP client with auth
-  index.ts            # CLI entry point
-  commands/
-    auth.ts           # Save API token (tgt auth)
-    version.ts        # Show CLI version (tgt version)
-    entry-list.ts     # List time entries + totals
-    project-list.ts   # List workspace projects
-    entry-delete.ts   # Delete a time entry
-    track.ts          # Start timer or log completed entry
-    stop.ts           # Stop running timer
-    tag-list.ts       # List workspace tags
-    entry-edit.ts     # Edit time entry (desc, project, tags)
-```
 
 ## License
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -5,19 +5,6 @@
 - **npm package**: `toggl-pilot`
 - **Binary command**: `tgt`
 
-## Before Publishing Checklist
-
-- [x] Add `bin` field to package.json: `{ "tgt": "./dist/index.js" }`
-- [x] Add build step (compile TS to JS)
-- [x] Add shebang `#!/usr/bin/env node` to entry point
-- [x] Add keywords to package.json (`toggl`, `toggl-track`, `time-tracking`, `cli`)
-- [x] Add `files` field to control published contents
-- [x] Add `prepublishOnly` script to ensure build runs before publish
-- [x] Implement `auth` command (see distributed-config.md)
-- [x] Update AGENTS.md project name
-- [x] Test `npm pack` to verify published contents
-- [ ] `npm publish --access public`
-
 ## Releasing
 
 ### PR Title Convention

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -7,15 +7,44 @@
 
 ## Before Publishing Checklist
 
-- [ ] Add `bin` field to package.json: `{ "tgt": "./dist/index.js" }`
-- [ ] Add build step (compile TS to JS)
-- [ ] Add shebang `#!/usr/bin/env node` to entry point
-- [ ] Add keywords to package.json (`toggl`, `toggl-track`, `time-tracking`, `cli`)
-- [ ] Add `.npmignore` or `files` field to control published contents
-- [ ] Implement `auth` command (see distributed-config.md)
-- [ ] Update AGENTS.md project name
-- [ ] Test `npm pack` to verify published contents
-- [ ] `npm publish`
+- [x] Add `bin` field to package.json: `{ "tgt": "./dist/index.js" }`
+- [x] Add build step (compile TS to JS)
+- [x] Add shebang `#!/usr/bin/env node` to entry point
+- [x] Add keywords to package.json (`toggl`, `toggl-track`, `time-tracking`, `cli`)
+- [x] Add `files` field to control published contents
+- [x] Add `prepublishOnly` script to ensure build runs before publish
+- [x] Implement `auth` command (see distributed-config.md)
+- [x] Update AGENTS.md project name
+- [x] Test `npm pack` to verify published contents
+- [ ] `npm publish --access public`
+
+## Releasing
+
+### PR Title Convention
+
+Prefix PR titles with the type of change:
+
+- `feat:` — new feature or enhancement (included in release notes)
+- `fix:` — bug fix (included in release notes)
+- `chore:`, `docs:`, `refactor:`, `test:` — excluded from release notes
+
+### Version Bump
+
+```bash
+npm version patch   # 0.1.0 → 0.1.1 (bug fixes)
+npm version minor   # 0.1.0 → 0.2.0 (new features)
+npm version major   # 0.1.0 → 1.0.0 (breaking changes)
+```
+
+This bumps `package.json`, creates a git commit and tag (e.g. `v0.2.0`). Then push:
+
+```bash
+git push --follow-tags
+```
+
+### Release Notes
+
+Release notes are auto-generated from `feat:` and `fix:` commits between tags. This will be set up in CI when a `v*` tag is pushed.
 
 ## Future Interface Expansion
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "tgt": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "start": "tsx src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,19 @@
 {
   "name": "toggl-pilot",
   "version": "0.1.0",
-  "private": true,
+  "description": "Unofficial CLI for Toggl Track time management",
+  "license": "MIT",
+  "author": "Stefano Locati",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stivlo/toggl-pilot.git"
+  },
+  "keywords": [
+    "toggl",
+    "toggl-track",
+    "cli",
+    "time-tracking"
+  ],
   "type": "module",
   "bin": {
     "tgt": "./dist/index.js"
@@ -31,7 +43,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "pre-commit": "tsx scripts/pre-commit.ts"
+    "pre-commit": "tsx scripts/pre-commit.ts",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   bundle: true,
   splitting: false,
   sourcemap: true,
+  banner: { js: '#!/usr/bin/env node' },
 });


### PR DESCRIPTION
## Summary

- Remove `"private": true` and add npm package metadata (`description`, `license`, `author`, `repository`, `keywords`)
- Add `prepublishOnly` script to ensure build runs before publish
- Add shebang banner (`#!/usr/bin/env node`) to tsup build output
- Update README with npm badges, `Install` section (`npm i -g toggl-pilot`), and `Quick Start` examples
- Verified `npm pack` output is clean (only `dist/`, `README.md`, `LICENSE`, `package.json`)

Closes #43