### PR TITLE
fix: duplicate shebang, wrong repo URL, and improve README (#50)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ See README.md for available commands and usage.
 ## Guidelines
 
 - **Never commit directly to `main`** — always create a feature branch first
+- **Never amend commits** that have been pushed to remote — create a new commit instead
 - **After merging a PR**, switch to `main`, run `git pull && git fetch --prune`,
   then delete the local branch (`git branch -D <branch>` — use `-D` since squash
   merges require force delete)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # toggl-pilot
 
-[![npm version](https://img.shields.io/npm/v/toggl-pilot.svg)](https://www.npmjs.com/package/toggl-pilot) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![npm version](https://img.shields.io/npm/v/toggl-pilot.svg)](https://www.npmjs.com/package/toggl-pilot)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GitHub](https://img.shields.io/badge/GitHub-toggl--pilot-blue?logo=github)](https://github.com/appforgelab/toggl-pilot)
 
 Unofficial CLI for [Toggl Track](https://toggl.com/) time management, using the [Toggl Track API v9](https://developers.track.toggl.com/docs/).
 
@@ -28,6 +30,8 @@ Running `tgt auth` saves your token so you don't need to pass it every time.
 You can also set the `TOGGL_API_TOKEN` environment variable, which takes
 priority over the saved config.
 
+Run `tgt` without arguments to see all available commands.
+
 ## Commands
 
 | Command                                 | Description                 | Docs                                         |
@@ -45,8 +49,12 @@ priority over the saved config.
 
 ## Configuration
 
-Config is saved to `~/.config/tgt/config.env` (macOS/Linux) or
+Run `tgt auth <token>` to save your API token to
+`~/.config/tgt/config.env` (macOS/Linux) or
 `%APPDATA%\tgt\config.env` (Windows).
+
+You can also set environment variables, which take priority over the config
+file:
 
 | Variable             | Required | Description                        |
 | -------------------- | -------- | ---------------------------------- |

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Stefano Locati",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stivlo/toggl-pilot.git"
+    "url": "git+https://github.com/appforgelab/toggl-pilot.git"
   },
   "keywords": [
     "toggl",
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "start": "tsx src/index.ts",
-    "build": "tsup",
+    "build": "tsup && tsx scripts/add-shebang.ts",
     "auth": "tsx src/index.ts auth",
     "version": "tsx src/index.ts version",
     "track": "tsx src/index.ts track",

--- a/scripts/add-shebang.ts
+++ b/scripts/add-shebang.ts
@@ -1,0 +1,12 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+
+const file = 'dist/index.js';
+
+if (!existsSync(file)) {
+  console.error(`Error: ${file} not found. Did the build succeed?`);
+  process.exit(1);
+}
+
+let content = readFileSync(file, 'utf8');
+content = '#!/usr/bin/env node\n' + content.replace(/^#!.*\n?/, '');
+writeFileSync(file, content);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,5 +8,4 @@ export default defineConfig({
   bundle: true,
   splitting: false,
   sourcemap: true,
-  banner: { js: '#!/usr/bin/env node' },
 });


### PR DESCRIPTION
## Summary

- Fix duplicate shebang in ESM build output (caused crash on `npm i -g toggl-pilot`)
- Fix wrong repository URL in `package.json` (`stivlo` → `appforgelab`), which caused 404s on npm doc links
- Add GitHub badge to README
- Mention `tgt auth` in Configuration section
- Add tip about running `tgt` with no args to see available commands
- Split badges to separate lines to satisfy MD013 line-length rule

Closes #50