### PR TITLE
chore: bump version to 0.1.1 (#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toggl-pilot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Unofficial CLI for Toggl Track time management",
   "license": "MIT",
   "author": "Stefano Locati",


### PR DESCRIPTION
## Summary

Bump version from 0.1.0 to 0.1.1 for the shebang fix republish.

After merging, the tag `v0.1.1` (already pushed to remote) will match this commit, then:

```
npm publish --access public
```