### PR TITLE
fix: update package-lock.json for v0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "toggl-pilot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toggl-pilot",
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "license": "MIT",
       "bin": {
         "tgt": "dist/index.js"
       },


### PR DESCRIPTION
## Summary

The version bump PR (#52) missed updating `package-lock.json`. This adds the lockfile change to match `package.json` v0.1.1.