### PR TITLE
docs: replace npm run with tgt in user-facing docs (#54)

### DIFF
--- a/docs/entry-delete.md
+++ b/docs/entry-delete.md
@@ -1,22 +1,20 @@
 # `entry-delete` — Delete a Time Entry
 
-Deletes a time entry by its ID. Find the ID using `npm run entry-list`.
+Deletes a time entry by its ID. Find the ID using `tgt entry-list`.
 
 ## Usage
 
 ```bash
-npm run entry-delete -- <entry_id>
+tgt entry-delete <entry_id>
 ```
-
-The `--` is required so npm passes the argument to the script.
 
 ## Example
 
 ```bash
-npm run entry-list
+tgt entry-list
 #   4383678597   20:02-20:13   0h10m   Ch 15 wrap up   Learning
 
-npm run entry-delete -- 4383678597
+tgt entry-delete 4383678597
 #   Deleted: Ch 15 wrap up (20:02-20:13) [Learning]
 ```
 

--- a/docs/entry-edit.md
+++ b/docs/entry-edit.md
@@ -6,16 +6,16 @@ state — running entries stay running, stopped entries stay stopped.
 ## Usage
 
 ```bash
-npm run entry-edit -- <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2]
+tgt entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2]
 ```
 
 ## Examples
 
 ```bash
-npm run entry-edit -- 4383745312 -d "Updated description"
-npm run entry-edit -- 4383745312 -p "Dev-Pilot"
-npm run entry-edit -- 4383745312 -t dev,review
-npm run entry-edit -- 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
+tgt entry-edit 4383745312 -d "Updated description"
+tgt entry-edit 4383745312 -p "Dev-Pilot"
+tgt entry-edit 4383745312 -t dev,review
+tgt entry-edit 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
 ```
 
 ## Options
@@ -26,7 +26,7 @@ npm run entry-edit -- 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
 | `--project`     | `-p`  | New project name (case-insensitive) |
 | `--tags`        | `-t`  | New tags (replaces existing)        |
 
-You must provide at least one option. Find the entry ID using `npm run entry-list`.
+You must provide at least one option. Find the entry ID using `tgt entry-list`.
 
 ## Output
 

--- a/docs/entry-list.md
+++ b/docs/entry-list.md
@@ -5,9 +5,9 @@ Lists all time entries for a given day with totals by project.
 ## Usage
 
 ```bash
-npm run entry-list                        # today
-npm run entry-list -- -d 2026-04-29       # specific date
-npm run entry-list -- --date 2026-04-29   # long form
+tgt entry-list                        # today
+tgt entry-list -d 2026-04-29          # specific date
+tgt entry-list --date 2026-04-29      # long form
 ```
 
 ## Output

--- a/docs/me.md
+++ b/docs/me.md
@@ -3,7 +3,7 @@
 Verifies your API token and shows your Toggl user info.
 
 ```bash
-npm run me
+tgt me
 ```
 
 **Output:**

--- a/docs/project-list.md
+++ b/docs/project-list.md
@@ -5,7 +5,7 @@ Lists all projects in your workspace with IDs, names, clients, and status.
 ## Usage
 
 ```bash
-npm run project-list
+tgt project-list
 ```
 
 ## Output

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -5,7 +5,7 @@ Stops the currently running timer. No arguments needed — it auto-detects the r
 ## Usage
 
 ```bash
-npm run stop
+tgt stop
 ```
 
 ## Output

--- a/docs/tag-list.md
+++ b/docs/tag-list.md
@@ -5,7 +5,7 @@ Lists all tags in your workspace.
 ## Usage
 
 ```bash
-npm run tag-list
+tgt tag-list
 ```
 
 ## Output
@@ -20,4 +20,4 @@ Tags in workspace 21355416
   123458       review
 ```
 
-Tags are created automatically when you use them with `npm run track -- -t tagname`. There's no need to create them separately.
+Tags are created automatically when you use them with `tgt track -t tagname`. There's no need to create them separately.

--- a/docs/track.md
+++ b/docs/track.md
@@ -5,19 +5,17 @@ Starts a running timer or logs a completed time entry with project and tags.
 ## Usage
 
 ```bash
-npm run track -- "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]
+tgt track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]
 ```
-
-The `--` is required so npm passes arguments to the script.
 
 ## Running Timer
 
 Omit `--at` and `--dur` to start a running timer:
 
 ```bash
-npm run track -- "Fixing login bug"
-npm run track -- "Code review" -p "Dev-Pilot"
-npm run track -- "Sprint planning" -p "Client-X" -t meeting,planning
+tgt track "Fixing login bug"
+tgt track "Code review" -p "Dev-Pilot"
+tgt track "Sprint planning" -p "Client-X" -t meeting,planning
 ```
 
 ## Log Completed Entry
@@ -25,9 +23,9 @@ npm run track -- "Sprint planning" -p "Client-X" -t meeting,planning
 Provide both `--at` and `--dur` to create a completed entry:
 
 ```bash
-npm run track -- "Morning standup" --at 09:00 --dur 30m
-npm run track -- "Code review" -p "Dev-Pilot" --at 10:00 --dur 1h
-npm run track -- "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
+tgt track "Morning standup" --at 09:00 --dur 30m
+tgt track "Code review" -p "Dev-Pilot" --at 10:00 --dur 1h
+tgt track "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
 ```
 
 ## Options
@@ -42,7 +40,7 @@ npm run track -- "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
 ## Project Lookup
 
 Projects are looked up by name (case-insensitive). If no match is found, you'll get an
-error. Use `npm run project-list` to see available names. If multiple projects share the
+error. Use `tgt project-list` to see available names. If multiple projects share the
 same name, the ambiguous matches are listed.
 
 ## Output

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -79,9 +79,7 @@ export async function entryEdit(args: string[]) {
     const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
     const matches = projects.filter((p) => p.name.toLowerCase() === projectName.toLowerCase());
     if (matches.length === 0) {
-      console.error(
-        `Project "${projectName}" not found. Use "npm run project-list" to list available projects.`
-      );
+      console.error(`Project "${projectName}" not found. Use "tgt project-list" to list available projects.`);
       process.exit(1);
     }
     if (matches.length > 1) {

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -69,9 +69,7 @@ export async function track(args: string[]) {
     const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
     const matches = projects.filter((p) => p.name.toLowerCase() === projectName.toLowerCase());
     if (matches.length === 0) {
-      console.error(
-        `Project "${projectName}" not found. Use "npm run project-list" to list available projects.`
-      );
+      console.error(`Project "${projectName}" not found. Use "tgt project-list" to list available projects.`);
       process.exit(1);
     }
     if (matches.length > 1) {


### PR DESCRIPTION
## Summary

- Replaced all `npm run <command> --` patterns with `tgt <command>` in 8 user-facing doc files
- Removed npm-specific `--` separator explanations that no longer apply
- Updated inline references (e.g. "Find the ID using `tgt entry-list`")

Closes #54