### PR TITLE
feat: add project-rename command (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,19 @@ Run `tgt` without arguments to see all available commands.
 
 ## Commands
 
-| Command                                 | Description                 | Docs                                         |
-| --------------------------------------- | --------------------------- | -------------------------------------------- |
-| `tgt auth <token>`                      | Save API token              |                                              |
-| `tgt version`                           | Show CLI version            |                                              |
-| `tgt me`                                | Verify authentication       | [docs/me.md](docs/me.md)                     |
-| `tgt entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
-| `tgt project-list`                      | List workspace projects     | [docs/project-list.md](docs/project-list.md) |
-| `tgt entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |
-| `tgt track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
-| `tgt stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
-| `tgt tag-list`                          | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)         |
-| `tgt entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
+| Command                                 | Description                 | Docs                                             |
+| --------------------------------------- | --------------------------- | ------------------------------------------------ |
+| `tgt auth <token>`                      | Save API token              |                                                  |
+| `tgt version`                           | Show CLI version            |                                                  |
+| `tgt me`                                | Verify authentication       | [docs/me.md](docs/me.md)                         |
+| `tgt entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)         |
+| `tgt project-list`                      | List workspace projects     | [docs/project-list.md](docs/project-list.md)     |
+| `tgt project-rename <id> "New Name"`    | Rename a project            | [docs/project-rename.md](docs/project-rename.md) |
+| `tgt entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md)     |
+| `tgt track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)                   |
+| `tgt stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                     |
+| `tgt tag-list`                          | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)             |
+| `tgt entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)         |
 
 ## Configuration
 

--- a/docs/project-rename.md
+++ b/docs/project-rename.md
@@ -1,0 +1,28 @@
+# `project-rename` — Rename a Project
+
+Renames an existing project in your workspace.
+
+## Usage
+
+```bash
+tgt project-rename <project_id> "New Name"
+```
+
+## Output
+
+```text
+Project 1234567890 renamed to "New Name"
+```
+
+## Arguments
+
+| Argument     | Description                |
+| ------------ | -------------------------- |
+| `project_id` | Toggl project ID to rename |
+| `"New Name"` | New name for the project   |
+
+## Examples
+
+```bash
+tgt project-rename 1234567890 "Website Redesign"
+```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "me": "tsx src/index.ts me",
     "entry-list": "tsx src/index.ts entry-list",
     "project-list": "tsx src/index.ts project-list",
+    "project-rename": "tsx src/index.ts project-rename",
     "entry-delete": "tsx src/index.ts entry-delete",
     "tag-list": "tsx src/index.ts tag-list",
     "entry-edit": "tsx src/index.ts entry-edit",

--- a/src/commands/entry-delete.ts
+++ b/src/commands/entry-delete.ts
@@ -12,7 +12,7 @@ interface TimeEntry {
 export async function entryDelete(args: string[]) {
   const id = args.find((a) => !a.startsWith('-'));
   if (!id) {
-    console.error('Usage: tsx src/index.ts entry-delete <entry_id>');
+    console.error('Usage: tgt entry-delete <entry_id>');
     process.exit(1);
   }
 

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -49,9 +49,7 @@ export function parseArgs(args: string[]): {
   }
 
   if (!id) {
-    throw new Error(
-      'Usage: tsx src/index.ts entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2]'
-    );
+    throw new Error('Usage: tgt entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2]');
   }
 
   if (!description && !project && !tags) {

--- a/src/commands/project-rename.ts
+++ b/src/commands/project-rename.ts
@@ -1,0 +1,24 @@
+import { config } from '../config.js';
+import { put } from '../api.js';
+
+interface Project {
+  id: number;
+  name: string;
+}
+
+export async function projectRename(args: string[]) {
+  const projectId = args[0];
+  const newName = args[1];
+
+  if (!projectId || !newName) {
+    console.error('Usage: tgt project-rename <project_id> "New Name"');
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+  const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
+    name: newName,
+  });
+
+  console.log(`Project ${updated.id} renamed to "${updated.name}"`);
+}

--- a/src/commands/project-rename.ts
+++ b/src/commands/project-rename.ts
@@ -15,10 +15,24 @@ export async function projectRename(args: string[]) {
     process.exit(1);
   }
 
-  const wsId = await config.getWorkspaceId();
-  const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
-    name: newName,
-  });
+  if (isNaN(Number(projectId))) {
+    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+    process.exit(1);
+  }
 
-  console.log(`Project ${updated.id} renamed to "${updated.name}"`);
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
+      name: newName,
+    });
+    console.log(`Project ${updated.id} renamed to "${updated.name}"`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Project ${projectId} not found.`);
+      return;
+    }
+    throw e;
+  }
 }

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -53,7 +53,7 @@ export function parseArgs(args: string[]): {
 
   if (!description) {
     throw new Error(
-      'Usage: tsx src/index.ts track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]'
+      'Usage: tgt track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]'
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
 import { entryEdit } from './commands/entry-edit.js';
+import { projectRename } from './commands/project-rename.js';
 import { auth } from './commands/auth.js';
 import { version } from './commands/version.js';
 
@@ -60,10 +61,13 @@ if (command === 'auth') {
     case 'entry-edit':
       entryEdit(args);
       break;
+    case 'project-rename':
+      projectRename(args);
+      break;
     default:
       console.error('Usage: tgt <command>');
       console.error(
-        'Commands: auth, version, me, entry-list [-d DATE], project-list, entry-delete <entry_id>, track, stop, tag-list, entry-edit'
+        'Commands: auth, version, me, entry-list [-d DATE], project-list, project-rename <project_id> "New Name", entry-delete <entry_id>, track, stop, tag-list, entry-edit'
       );
   }
 }

--- a/tests/entry-delete.test.ts
+++ b/tests/entry-delete.test.ts
@@ -33,7 +33,7 @@ describe('entryDelete command', () => {
 
     await expect(entryDelete([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tsx src/index.ts entry-delete <entry_id>');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgt entry-delete <entry_id>');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();

--- a/tests/project-rename.test.ts
+++ b/tests/project-rename.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  put: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { put } from '../src/api.js';
+import { projectRename } from '../src/commands/project-rename.js';
+
+const mockedPut = vi.mocked(put);
+
+describe('projectRename command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no args provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRename([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgt project-rename <project_id> "New Name"');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits with usage message when only project ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRename(['123'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgt project-rename <project_id> "New Name"');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits with error when project ID is not numeric', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRename(['abc', 'New Name'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('renames project and prints confirmation', async () => {
+    mockedPut.mockResolvedValue({ id: 456, name: 'New Name' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectRename(['456', 'New Name']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      name: 'New Name',
+    });
+    expect(logSpy).toHaveBeenCalledWith('Project 456 renamed to "New Name"');
+    logSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await projectRename(['999', 'New Name']);
+
+    expect(logSpy).toHaveBeenCalledWith('Project 999 not found.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(projectRename(['123', 'New Name'])).rejects.toThrow('500');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tgt project-rename <project_id> "New Name"` command that renames a project via `PUT /workspaces/{workspace_id}/projects/{project_id}`
- Add route in `src/index.ts`, npm script in `package.json`, docs, and README entry
- Update usage messages in `entry-delete`, `entry-edit`, and `track` to use user-facing `tgt` prefix instead of `tsx src/index.ts`

Closes #21