### PR TITLE
feat: add CI release and publish workflows (#44)

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,117 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump-type:
+        description: Version bump type
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: 22
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bump version
+        id: bump
+        run: |
+          npm version ${{ github.event.inputs.bump-type }} --no-git-tag-version
+          NEW_VERSION=$(jq -r .version package.json)
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="$PREV_TAG..HEAD"
+          else
+            RANGE="--all"
+          fi
+
+          FEAT_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^feat" 2>/dev/null || true)
+          FIX_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^fix" 2>/dev/null || true)
+
+          NOTES=""
+          if [ -n "$FEAT_COMMITS" ]; then
+            NOTES="${NOTES}## What's New\n\n${FEAT_COMMITS}\n\n"
+          fi
+          if [ -n "$FIX_COMMITS" ]; then
+            NOTES="${NOTES}## Bug Fixes\n\n${FIX_COMMITS}\n\n"
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="No notable changes.\n\n"
+          fi
+          NOTES="${NOTES}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ steps.bump.outputs.tag }}"
+
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch and commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b ${{ steps.bump.outputs.branch }}
+          git add package.json package-lock.json
+          git commit -m "chore: release ${{ steps.bump.outputs.tag }}"
+          git push origin ${{ steps.bump.outputs.branch }}
+
+      - name: Create Pull Request
+        run: |
+          gh pr create \
+            --title "chore: release ${{ steps.bump.outputs.tag }}" \
+            --body "$(cat <<'PRBODY'
+          ## Release ${{ steps.bump.outputs.tag }}
+
+          Version bump from `${{ github.event.inputs.bump-type }}`. Review and merge to proceed with publishing.
+
+          After merging, run the **Publish** workflow to publish to npm.
+
+          ---
+
+          ${{ steps.notes.outputs.notes }}
+          PRBODY
+          )" \
+            --base main \
+            --head ${{ steps.bump.outputs.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create draft GitHub Release
+        run: |
+          gh release create ${{ steps.bump.outputs.tag }} \
+            --draft \
+            --title "${{ steps.bump.outputs.tag }}" \
+            --notes "${{ steps.notes.outputs.notes }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -71,7 +71,9 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="No notable changes.\n\n"
           fi
-          NOTES="${NOTES}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ steps.bump.outputs.tag }}"
+          if [ -n "$PREV_TAG" ]; then
+            NOTES="${NOTES}**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ steps.bump.outputs.tag }}"
+          fi
 
           echo "notes<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$NOTES" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -88,22 +88,29 @@ jobs:
           git commit -m "chore: release ${{ steps.bump.outputs.tag }}"
           git push origin ${{ steps.bump.outputs.branch }}
 
-      - name: Create Pull Request
+      - name: Write release notes to file
         run: |
-          gh pr create \
-            --title "chore: release ${{ steps.bump.outputs.tag }}" \
-            --body "$(cat <<'PRBODY'
+          echo "${{ steps.notes.outputs.notes }}" > release-notes.md
+
+      - name: Write PR body to file
+        run: |
+          cat > pr-body.md <<EOF
           ## Release ${{ steps.bump.outputs.tag }}
 
-          Version bump from `${{ github.event.inputs.bump-type }}`. Review and merge to proceed with publishing.
+          Version bump from \`${{ github.event.inputs.bump-type }}\`. Review and merge to proceed with publishing.
 
           After merging, run the **Publish** workflow to publish to npm.
 
           ---
 
           ${{ steps.notes.outputs.notes }}
-          PRBODY
-          )" \
+          EOF
+
+      - name: Create Pull Request
+        run: |
+          gh pr create \
+            --title "chore: release ${{ steps.bump.outputs.tag }}" \
+            --body-file pr-body.md \
             --base main \
             --head ${{ steps.bump.outputs.branch }}
         env:
@@ -114,6 +121,6 @@ jobs:
           gh release create ${{ steps.bump.outputs.tag }} \
             --draft \
             --title "${{ steps.bump.outputs.tag }}" \
-            --notes "${{ steps.notes.outputs.notes }}"
+            --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -58,8 +58,8 @@ jobs:
             RANGE="--all"
           fi
 
-          FEAT_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^feat" 2>/dev/null || true)
-          FIX_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^fix" 2>/dev/null || true)
+          FEAT_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^feat[(:(]" 2>/dev/null || true)
+          FIX_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^fix[(:(]" 2>/dev/null || true)
 
           NOTES=""
           if [ -n "$FEAT_COMMITS" ]; then

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -58,8 +58,8 @@ jobs:
             RANGE="--all"
           fi
 
-          FEAT_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^feat[(:(]" 2>/dev/null || true)
-          FIX_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^fix[(:(]" 2>/dev/null || true)
+          FEAT_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^feat:" 2>/dev/null || true)
+          FIX_COMMITS=$(git log $RANGE --pretty=format:"- %s" --grep="^fix:" 2>/dev/null || true)
 
           NOTES=""
           if [ -n "$FEAT_COMMITS" ]; then

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -90,11 +90,11 @@ jobs:
 
       - name: Write release notes to file
         run: |
-          echo "${{ steps.notes.outputs.notes }}" > release-notes.md
+          printf '%s' '${{ steps.notes.outputs.notes }}' > release-notes.md
 
       - name: Write PR body to file
         run: |
-          cat > pr-body.md <<EOF
+          cat > pr-body.md <<'EOF'
           ## Release ${{ steps.bump.outputs.tag }}
 
           Version bump from \`${{ github.event.inputs.bump-type }}\`. Review and merge to proceed with publishing.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Verify version matches package.json
         run: |
@@ -58,9 +60,13 @@ jobs:
 
       - name: Create and push git tag
         run: |
+          TAG="v${{ github.event.inputs.version }}"
+          if git tag -l "$TAG" | grep -q .; then
+            echo "Error: tag $TAG already exists"
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          TAG="v${{ github.event.inputs.version }}"
           git tag "$TAG"
           git push origin "$TAG"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,11 +2,6 @@ name: Publish
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: Version to publish (e.g. 0.2.0)
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -24,13 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify version matches package.json
+      - name: Read version from package.json
+        id: version
         run: |
-          PACKAGE_VERSION=$(jq -r .version package.json)
-          if [ "$PACKAGE_VERSION" != "${{ github.event.inputs.version }}" ]; then
-            echo "Error: package.json has version $PACKAGE_VERSION but expected ${{ github.event.inputs.version }}"
-            exit 1
-          fi
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -60,7 +54,7 @@ jobs:
 
       - name: Create and push git tag
         run: |
-          TAG="v${{ github.event.inputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
           if git tag -l "$TAG" | grep -q .; then
             echo "Error: tag $TAG already exists"
             exit 1
@@ -80,7 +74,6 @@ jobs:
 
       - name: Publish GitHub Release
         run: |
-          TAG="v${{ github.event.inputs.version }}"
-          gh release edit "$TAG" --draft=false
+          gh release edit "${{ steps.version.outputs.tag }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,80 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish (e.g. 0.2.0)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: 22
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Verify version matches package.json
+        run: |
+          PACKAGE_VERSION=$(jq -r .version package.json)
+          if [ "$PACKAGE_VERSION" != "${{ github.event.inputs.version }}" ]; then
+            echo "Error: package.json has version $PACKAGE_VERSION but expected ${{ github.event.inputs.version }}"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type checking
+        run: npm run typecheck
+
+      - name: Run markdown lint
+        run: npm run lint:md
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run format check
+        run: npm run format:check
+
+      - name: Create and push git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="v${{ github.event.inputs.version }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish GitHub Release
+        run: |
+          TAG="v${{ github.event.inputs.version }}"
+          gh release edit "$TAG" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -15,23 +15,40 @@ Prefix PR titles with the type of change:
 - `fix:` — bug fix (included in release notes)
 - `chore:`, `docs:`, `refactor:`, `test:` — excluded from release notes
 
-### Version Bump
+### Release Process (via GitHub Actions)
 
-```bash
-npm version patch   # 0.1.0 → 0.1.1 (bug fixes)
-npm version minor   # 0.1.0 → 0.2.0 (new features)
-npm version major   # 0.1.0 → 1.0.0 (breaking changes)
-```
+The release uses two manual workflows.
 
-This bumps `package.json`, creates a git commit and tag (e.g. `v0.2.0`). Then push:
+#### Step 1: Prepare Release
 
-```bash
-git push --follow-tags
-```
+1. Go to **Actions → Prepare Release → Run workflow**
+2. Select bump type: `patch`, `minor`, or `major`
+3. The workflow will:
+   - Create a `release/vX.Y.Z` branch with the version bump
+   - Create a PR with auto-generated release notes from `feat:`/`fix:` commits
+   - Create a **draft** GitHub Release
 
-### Release Notes
+#### Step 2: Review & Merge
 
-Release notes are auto-generated from `feat:` and `fix:` commits between tags. This will be set up in CI when a `v*` tag is pushed.
+1. Review the PR (package.json + package-lock.json version bump)
+2. Edit the draft release notes if needed (at Releases → draft)
+3. Merge the PR
+
+#### Step 3: Publish
+
+1. Go to **Actions → Publish → Run workflow**
+2. Enter the version number (e.g. `0.2.0`)
+3. The workflow will:
+   - Verify the version matches package.json
+   - Run all checks (typecheck, lint, test, format)
+   - Create and push the git tag
+   - Build and publish to npm
+   - Mark the draft GitHub Release as published
+
+### Prerequisites
+
+- `NPM_TOKEN` must be configured as a GitHub Actions secret
+  (npmjs.com → Access Tokens → Generate New Token → publish type)
 
 ## Future Interface Expansion
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -37,7 +37,7 @@ The release uses two manual workflows.
 #### Step 3: Publish
 
 1. Go to **Actions → Publish → Run workflow**
-2. Enter the version number (e.g. `0.2.0`)
+2. The workflow reads the version from `package.json` — no input needed
 3. The workflow will:
    - Verify the version matches package.json
    - Run all checks (typecheck, lint, test, format)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -39,7 +39,7 @@ The release uses two manual workflows.
 1. Go to **Actions → Publish → Run workflow**
 2. The workflow reads the version from `package.json` — no input needed
 3. The workflow will:
-   - Verify the version matches package.json
+   - Read the version from `package.json`
    - Run all checks (typecheck, lint, test, format)
    - Create and push the git tag
    - Build and publish to npm


### PR DESCRIPTION
## Summary

Two-workflow manual release process for publishing to npm:

- **Prepare Release** (`workflow_dispatch`) — creates a version bump PR and draft GitHub Release with auto-generated notes from `feat:`/`fix:` commits
- **Publish** (`workflow_dispatch`) — after merging the PR, runs all checks, creates the tag, publishes to npm, and marks the draft Release as published

Also updates `docs/publishing.md` with step-by-step instructions.

**Prerequisite**: `NPM_TOKEN` must be added as a GitHub Actions secret before the Publish workflow can run.

Closes #44