### PR TITLE
fix: use npm OIDC trusted publishing with provenance (#63)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   NODE_VERSION: 22
@@ -33,6 +34,7 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
           registry-url: https://registry.npmjs.org
+          provenance: true
 
       - name: Install dependencies
         run: npm ci
@@ -68,7 +70,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -47,8 +47,9 @@ The release uses two manual workflows.
 
 ### Prerequisites
 
+- npm trusted publisher configured on npmjs.com for this repo and `publish.yaml` workflow
 - `NPM_TOKEN` must be configured as a GitHub Actions secret
-  (npmjs.com → Access Tokens → Generate New Token → publish type)
+  (npmjs.com → Access Tokens → Generate New Token → Automation type)
 
 ## Future Interface Expansion
 


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission for OIDC token generation
- Enable `provenance: true` in `actions/setup-node` for signed provenance statements
- Add `--provenance` flag to `npm publish`
- Still requires `NPM_TOKEN` secret (npm OIDC trusted publisher needs both the token and OIDC for provenance signing)

**Note**: You still need to add `NPM_TOKEN` as a GitHub Actions secret (npmjs.com → Access Tokens → Automation type). The OIDC trusted publisher on npmjs.com handles provenance signing, but `NODE_AUTH_TOKEN` is still needed for authentication.

Closes #63