### PR TITLE
fix: remove NPM_TOKEN, use npm trusted publishing OIDC only (#63)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,6 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
           registry-url: https://registry.npmjs.org
-          provenance: true
 
       - name: Install dependencies
         run: npm ci
@@ -70,9 +69,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Publish GitHub Release
         run: |

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -48,8 +48,7 @@ The release uses two manual workflows.
 ### Prerequisites
 
 - npm trusted publisher configured on npmjs.com for this repo and `publish.yaml` workflow
-- `NPM_TOKEN` must be configured as a GitHub Actions secret
-  (npmjs.com → Access Tokens → Generate New Token → Automation type)
+- No `NPM_TOKEN` secret needed — OIDC handles authentication automatically
 
 ## Future Interface Expansion
 


### PR DESCRIPTION
## Summary

Per npm's trusted publishing docs, OIDC replaces the need for `NPM_TOKEN` entirely:
- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env var from publish step
- Removed `--provenance` flag (auto-generated with trusted publishing)
- Removed `provenance: true` from setup-node (not needed)
- Only requires `id-token: write` permission + `registry-url` in setup-node

**Important**: The workflow filename configured on npmjs.com must match exactly (`publish.yaml`).

Closes #63