### PR TITLE
fix: unset NODE_AUTH_TOKEN so npm uses OIDC (#63)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,7 +69,9 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          unset NODE_AUTH_TOKEN
+          npm publish --access public
 
       - name: Publish GitHub Release
         run: |


### PR DESCRIPTION
## Summary

`actions/setup-node` with `registry-url` creates an `.npmrc` referencing `NODE_AUTH_TOKEN`, and GitHub provides `GITHUB_TOKEN` as that env var. npm tries this (invalid) token first and gets a 404, never falling back to OIDC.

Fix: explicitly `unset NODE_AUTH_TOKEN` before `npm publish` so npm uses the OIDC trusted publishing flow.