### PR TITLE
fix: override NODE_AUTH_TOKEN to empty for OIDC (#63)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,9 +69,9 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: |
-          unset NODE_AUTH_TOKEN
-          npm publish --access public
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ""
 
       - name: Publish GitHub Release
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: package-lock.json
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -70,8 +69,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ""
 
       - name: Publish GitHub Release
         run: |


### PR DESCRIPTION
## Summary

`unset NODE_AUTH_TOKEN` didn't work because GitHub Actions sets it at the job level. Using the step-level `env` to override it to an empty string should take precedence and let npm fall back to OIDC trusted publishing.