### PR TITLE
fix: add repository name and clean up bin path for OIDC (#63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Stefano Locati",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/appforgelab/toggl-pilot.git"
+    "url": "git+https://github.com/appforgelab/toggl-pilot.git",
+    "name": "appforgelab/toggl-pilot"
   },
   "keywords": [
     "toggl",
@@ -16,7 +17,7 @@
   ],
   "type": "module",
   "bin": {
-    "tgt": "./dist/index.js"
+    "tgt": "dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- Add `"name": "appforgelab/toggl-pilot"` to `repository` in package.json — npm uses this to match the trusted publisher config
- Run `npm pkg fix` which cleaned up the bin path (`./dist/index.js` → `dist/index.js`)
- Workflow already has `registry-url` and `NODE_AUTH_TOKEN` removed from previous PRs

These changes should allow npm's OIDC trusted publishing to work without any tokens.