### PR TITLE
fix: upgrade npm to v11 and restore registry-url for OIDC trusted publishing (#63)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -68,7 +68,10 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          rm -f .npmrc ~/.npmrc
+          npm config delete _authToken || true
+          npm publish --access public
 
       - name: Publish GitHub Release
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: package-lock.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci
@@ -68,10 +72,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: |
-          rm -f .npmrc ~/.npmrc
-          npm config delete _authToken || true
-          npm publish --access public
+        run: npm publish --access public
 
       - name: Publish GitHub Release
         run: |


### PR DESCRIPTION
## Problem

Publish workflow fails with `ENEEDAUTH` — npm requires authentication. 8 consecutive failures across multiple attempted fixes (removing tokens, unsetting env vars, cleaning .npmrc). The actual root cause: **npm CLI on the runner (v10.9.7) does not support OIDC trusted publishing**, which requires npm >= 11.5.1.

## Changes

- Restore `registry-url: https://registry.npmjs.org` on `setup-node` (required for OIDC token exchange)
- Add step to upgrade npm to v11 (`npm install -g npm@11`) after `setup-node`
- Remove `.npmrc` cleanup and `npm config delete _authToken` steps that were counterproductive (they deleted the OIDC config created by `setup-node`)

## Verification checklist

- [x] `id-token: write` permission is set in workflow
- [x] Trusted publisher configured on npmjs.com for `appforgelab/toggl-pilot` with workflow filename `publish.yaml`

Closes #63