### PR TITLE
fix: upgrade to Node 24 for npm 11.x OIDC trusted publishing (#63)

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: 24
 
 jobs:
   prepare-release:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: 24
 
 jobs:
   publish:
@@ -34,9 +34,6 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
           registry-url: https://registry.npmjs.org
-
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

Previous fix (#73) tried to upgrade npm in-place with `npm install -g npm@11`, but the runner's npm 10.9.7 is too broken to self-upgrade (`MODULE_NOT_FOUND: promise-retry`).

## Changes

- Upgrade `NODE_VERSION` from 22 to 24 in both `publish.yaml` and `prepare-release.yaml`
- Remove the broken `npm install -g npm@11` step (Node 24 ships with npm 11.x natively)
- `registry-url` is already set (from #73)

## Why Node 24

Node 22 on the runner ships npm 10.9.7 which:
1. Doesn't support OIDC trusted publishing (requires npm >= 11.5.1)
2. Can't self-upgrade (broken module resolution)

Node 24 LTS ships with npm 11.x, which has native OIDC support.

Closes #63