### PR TITLE
refactor: rename CLI binary from tgt to tgp (#59)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ CLI tool for Toggl Track time management. TypeScript, runs via `tsx`.
 
 - Node 22 + TypeScript (strict mode, ES modules)
 - `tsx` for running TS directly
-- Config via `~/.config/tgt/config.env` (macOS/Linux) or `%APPDATA%\tgt\config.env` (Windows)
+- Config via `~/.config/tgp/config.env` (macOS/Linux) or `%APPDATA%\tgp\config.env` (Windows)
 - No framework — plain `fetch` for HTTP, no CLI parser yet
 
 ## Commands
@@ -64,7 +64,7 @@ Example PR title: `feat: set up version management and workflow (#42)`
 
 ## Code Conventions
 
-- **Usage messages** should use `tgt <command>` (user-facing), not `tsx src/index.ts <command>` (dev-facing)
+- **Usage messages** should use `tgp <command>` (user-facing), not `tsx src/index.ts <command>` (dev-facing)
 
 ## API Quota (Free Plan)
 

--- a/README.md
+++ b/README.md
@@ -17,42 +17,42 @@ npm install -g toggl-pilot
 ## Quick Start
 
 ```bash
-tgt auth <your-api-token>
-tgt me
-tgt track "Working on feature" -p "My Project"
-tgt stop
-tgt entry-list
+tgp auth <your-api-token>
+tgp me
+tgp track "Working on feature" -p "My Project"
+tgp stop
+tgp entry-list
 ```
 
 Get your API token from your [Toggl Profile](https://track.toggl.com/profile) (scroll to API Token section).
 
-Running `tgt auth` saves your token so you don't need to pass it every time.
+Running `tgp auth` saves your token so you don't need to pass it every time.
 You can also set the `TOGGL_API_TOKEN` environment variable, which takes
 priority over the saved config.
 
-Run `tgt` without arguments to see all available commands.
+Run `tgp` without arguments to see all available commands.
 
 ## Commands
 
 | Command                                 | Description                 | Docs                                             |
 | --------------------------------------- | --------------------------- | ------------------------------------------------ |
-| `tgt auth <token>`                      | Save API token              |                                                  |
-| `tgt version`                           | Show CLI version            |                                                  |
-| `tgt me`                                | Verify authentication       | [docs/me.md](docs/me.md)                         |
-| `tgt entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)         |
-| `tgt project-list`                      | List workspace projects     | [docs/project-list.md](docs/project-list.md)     |
-| `tgt project-rename <id> "New Name"`    | Rename a project            | [docs/project-rename.md](docs/project-rename.md) |
-| `tgt entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md)     |
-| `tgt track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)                   |
-| `tgt stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                     |
-| `tgt tag-list`                          | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)             |
-| `tgt entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)         |
+| `tgp auth <token>`                      | Save API token              |                                                  |
+| `tgp version`                           | Show CLI version            |                                                  |
+| `tgp me`                                | Verify authentication       | [docs/me.md](docs/me.md)                         |
+| `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)         |
+| `tgp project-list`                      | List workspace projects     | [docs/project-list.md](docs/project-list.md)     |
+| `tgp project-rename <id> "New Name"`    | Rename a project            | [docs/project-rename.md](docs/project-rename.md) |
+| `tgp entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md)     |
+| `tgp track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)                   |
+| `tgp stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                     |
+| `tgp tag-list`                          | List workspace tags         | [docs/tag-list.md](docs/tag-list.md)             |
+| `tgp entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)         |
 
 ## Configuration
 
-Run `tgt auth <token>` to save your API token to
-`~/.config/tgt/config.env` (macOS/Linux) or
-`%APPDATA%\tgt\config.env` (Windows).
+Run `tgp auth <token>` to save your API token to
+`~/.config/tgp/config.env` (macOS/Linux) or
+`%APPDATA%\tgp\config.env` (Windows).
 
 You can also set environment variables, which take priority over the config
 file:

--- a/docs/distributed-config.md
+++ b/docs/distributed-config.md
@@ -22,12 +22,12 @@ Resolved by `src/paths.ts` — no external dependencies.
 
 |                 | Config                     | Cache                       |
 | --------------- | -------------------------- | --------------------------- |
-| **macOS/Linux** | `~/.config/tgt/config.env` | `~/.cache/tgt/`             |
-| **Windows**     | `%APPDATA%\tgt\config.env` | `%LOCALAPPDATA%\tgt\Cache\` |
+| **macOS/Linux** | `~/.config/tgp/config.env` | `~/.cache/tgp/`             |
+| **Windows**     | `%APPDATA%\tgp\config.env` | `%LOCALAPPDATA%\tgp\Cache\` |
 
 ### Config File
 
-Example (`~/.config/tgt/config.env`):
+Example (`~/.config/tgp/config.env`):
 
 ```env
 TOGGL_API_TOKEN=your_token_here
@@ -38,16 +38,16 @@ TOGGL_WORKSPACE_ID=123456
 
 ```text
 $ npm i -g toggl-pilot
-$ tgt
-  No config found. Run: tgt auth <api-token>
+$ tgp
+  No config found. Run: tgp auth <api-token>
   Or set TOGGL_API_TOKEN in your environment.
   Get your token at https://track.toggl.com/profile
 
-$ tgt auth my_api_token_here
-  Config saved to ~/.config/tgt/config.env
+$ tgp auth my_api_token_here
+  Config saved to ~/.config/tgp/config.env
   Authenticated as Stefano Locati (user@domain.com)
 
-$ tgt me
+$ tgp me
   Authenticated as: Stefano Locati (user@domain.com)
   Default workspace: 123456
 ```
@@ -64,5 +64,5 @@ $ tgt me
 ### Notes
 
 - Config file is plain text — avoid storing anything beyond the API token
-- `tgt auth` warns if config file has overly permissive permissions (suggests `chmod 600` on macOS/Linux)
+- `tgp auth` warns if config file has overly permissive permissions (suggests `chmod 600` on macOS/Linux)
 - Config file is created with mode `0o600`

--- a/docs/entry-delete.md
+++ b/docs/entry-delete.md
@@ -1,20 +1,20 @@
 # `entry-delete` — Delete a Time Entry
 
-Deletes a time entry by its ID. Find the ID using `tgt entry-list`.
+Deletes a time entry by its ID. Find the ID using `tgp entry-list`.
 
 ## Usage
 
 ```bash
-tgt entry-delete <entry_id>
+tgp entry-delete <entry_id>
 ```
 
 ## Example
 
 ```bash
-tgt entry-list
+tgp entry-list
 #   4383678597   20:02-20:13   0h10m   Ch 15 wrap up   Learning
 
-tgt entry-delete 4383678597
+tgp entry-delete 4383678597
 #   Deleted: Ch 15 wrap up (20:02-20:13) [Learning]
 ```
 

--- a/docs/entry-edit.md
+++ b/docs/entry-edit.md
@@ -6,16 +6,16 @@ state — running entries stay running, stopped entries stay stopped.
 ## Usage
 
 ```bash
-tgt entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2]
+tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2]
 ```
 
 ## Examples
 
 ```bash
-tgt entry-edit 4383745312 -d "Updated description"
-tgt entry-edit 4383745312 -p "Dev-Pilot"
-tgt entry-edit 4383745312 -t dev,review
-tgt entry-edit 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
+tgp entry-edit 4383745312 -d "Updated description"
+tgp entry-edit 4383745312 -p "Dev-Pilot"
+tgp entry-edit 4383745312 -t dev,review
+tgp entry-edit 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
 ```
 
 ## Options
@@ -26,7 +26,7 @@ tgt entry-edit 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
 | `--project`     | `-p`  | New project name (case-insensitive) |
 | `--tags`        | `-t`  | New tags (replaces existing)        |
 
-You must provide at least one option. Find the entry ID using `tgt entry-list`.
+You must provide at least one option. Find the entry ID using `tgp entry-list`.
 
 ## Output
 

--- a/docs/entry-list.md
+++ b/docs/entry-list.md
@@ -5,9 +5,9 @@ Lists all time entries for a given day with totals by project.
 ## Usage
 
 ```bash
-tgt entry-list                        # today
-tgt entry-list -d 2026-04-29          # specific date
-tgt entry-list --date 2026-04-29      # long form
+tgp entry-list                        # today
+tgp entry-list -d 2026-04-29          # specific date
+tgp entry-list --date 2026-04-29      # long form
 ```
 
 ## Output

--- a/docs/interactive-mode.md
+++ b/docs/interactive-mode.md
@@ -42,7 +42,7 @@ $ npm run track
 
 ### Relationship to Shell Completion & Cache
 
-Interactive mode and shell completion can share the same cache (`~/.tgt-cache.json`):
+Interactive mode and shell completion can share the same cache (`~/.tgp-cache.json`):
 
 - When prompting for a project → show cached project list
   as selectable options

--- a/docs/me.md
+++ b/docs/me.md
@@ -3,7 +3,7 @@
 Verifies your API token and shows your Toggl user info.
 
 ```bash
-tgt me
+tgp me
 ```
 
 **Output:**

--- a/docs/project-list.md
+++ b/docs/project-list.md
@@ -5,7 +5,7 @@ Lists all projects in your workspace with IDs, names, clients, and status.
 ## Usage
 
 ```bash
-tgt project-list
+tgp project-list
 ```
 
 ## Output

--- a/docs/project-rename.md
+++ b/docs/project-rename.md
@@ -5,7 +5,7 @@ Renames an existing project in your workspace.
 ## Usage
 
 ```bash
-tgt project-rename <project_id> "New Name"
+tgp project-rename <project_id> "New Name"
 ```
 
 ## Output
@@ -24,5 +24,5 @@ Project 1234567890 renamed to "New Name"
 ## Examples
 
 ```bash
-tgt project-rename 1234567890 "Website Redesign"
+tgp project-rename 1234567890 "Website Redesign"
 ```

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -3,7 +3,7 @@
 ## Identity
 
 - **npm package**: `toggl-pilot`
-- **Binary command**: `tgt`
+- **Binary command**: `tgp`
 
 ## Releasing
 
@@ -54,6 +54,6 @@ The release uses two manual workflows.
 
 The `toggl-pilot` name scales beyond CLI:
 
-- `tgt` — CLI mode (current)
-- `tgt` — TUI mode (just `tgt` with no args, see interactive-mode.md)
+- `tgp` — CLI mode (current)
+- `tgp` — TUI mode (just `tgp` with no args, see interactive-mode.md)
 - Desktop app — `toggl-pilot` works as an app name too

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -12,7 +12,7 @@ Add shell tab completion for commands, flags, and dynamic data (project names, t
 
 ## Caching Strategy
 
-Cache file: `~/.tgt-cache.json`
+Cache file: `~/.tgp-cache.json`
 
 ```json
 {

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -5,7 +5,7 @@ Stops the currently running timer. No arguments needed — it auto-detects the r
 ## Usage
 
 ```bash
-tgt stop
+tgp stop
 ```
 
 ## Output

--- a/docs/tag-list.md
+++ b/docs/tag-list.md
@@ -5,7 +5,7 @@ Lists all tags in your workspace.
 ## Usage
 
 ```bash
-tgt tag-list
+tgp tag-list
 ```
 
 ## Output
@@ -20,4 +20,4 @@ Tags in workspace 21355416
   123458       review
 ```
 
-Tags are created automatically when you use them with `tgt track -t tagname`. There's no need to create them separately.
+Tags are created automatically when you use them with `tgp track -t tagname`. There's no need to create them separately.

--- a/docs/track.md
+++ b/docs/track.md
@@ -5,7 +5,7 @@ Starts a running timer or logs a completed time entry with project and tags.
 ## Usage
 
 ```bash
-tgt track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]
+tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]
 ```
 
 ## Running Timer
@@ -13,9 +13,9 @@ tgt track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1
 Omit `--at` and `--dur` to start a running timer:
 
 ```bash
-tgt track "Fixing login bug"
-tgt track "Code review" -p "Dev-Pilot"
-tgt track "Sprint planning" -p "Client-X" -t meeting,planning
+tgp track "Fixing login bug"
+tgp track "Code review" -p "Dev-Pilot"
+tgp track "Sprint planning" -p "Client-X" -t meeting,planning
 ```
 
 ## Log Completed Entry
@@ -23,9 +23,9 @@ tgt track "Sprint planning" -p "Client-X" -t meeting,planning
 Provide both `--at` and `--dur` to create a completed entry:
 
 ```bash
-tgt track "Morning standup" --at 09:00 --dur 30m
-tgt track "Code review" -p "Dev-Pilot" --at 10:00 --dur 1h
-tgt track "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
+tgp track "Morning standup" --at 09:00 --dur 30m
+tgp track "Code review" -p "Dev-Pilot" --at 10:00 --dur 1h
+tgp track "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
 ```
 
 ## Options
@@ -40,7 +40,7 @@ tgt track "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
 ## Project Lookup
 
 Projects are looked up by name (case-insensitive). If no match is found, you'll get an
-error. Use `tgt project-list` to see available names. If multiple projects share the
+error. Use `tgp project-list` to see available names. If multiple projects share the
 same name, the ambiguous matches are listed.
 
 ## Output

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.6",
       "license": "MIT",
       "bin": {
-        "tgt": "dist/index.js"
+        "tgp": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "type": "module",
   "bin": {
-    "tgt": "dist/index.js"
+    "tgp": "dist/index.js"
   },
   "files": [
     "dist",

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -10,7 +10,7 @@ interface Me {
 export async function auth(args: string[]) {
   const token = args[0];
   if (!token) {
-    console.error('Usage: tgt auth <api-token>');
+    console.error('Usage: tgp auth <api-token>');
     console.error('Get your token at https://track.toggl.com/profile');
     process.exit(1);
   }

--- a/src/commands/entry-delete.ts
+++ b/src/commands/entry-delete.ts
@@ -12,7 +12,7 @@ interface TimeEntry {
 export async function entryDelete(args: string[]) {
   const id = args.find((a) => !a.startsWith('-'));
   if (!id) {
-    console.error('Usage: tgt entry-delete <entry_id>');
+    console.error('Usage: tgp entry-delete <entry_id>');
     process.exit(1);
   }
 

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -49,7 +49,7 @@ export function parseArgs(args: string[]): {
   }
 
   if (!id) {
-    throw new Error('Usage: tgt entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2]');
+    throw new Error('Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2]');
   }
 
   if (!description && !project && !tags) {
@@ -77,7 +77,7 @@ export async function entryEdit(args: string[]) {
     const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
     const matches = projects.filter((p) => p.name.toLowerCase() === projectName.toLowerCase());
     if (matches.length === 0) {
-      console.error(`Project "${projectName}" not found. Use "tgt project-list" to list available projects.`);
+      console.error(`Project "${projectName}" not found. Use "tgp project-list" to list available projects.`);
       process.exit(1);
     }
     if (matches.length > 1) {

--- a/src/commands/project-rename.ts
+++ b/src/commands/project-rename.ts
@@ -11,7 +11,7 @@ export async function projectRename(args: string[]) {
   const newName = args[1];
 
   if (!projectId || !newName) {
-    console.error('Usage: tgt project-rename <project_id> "New Name"');
+    console.error('Usage: tgp project-rename <project_id> "New Name"');
     process.exit(1);
   }
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -53,7 +53,7 @@ export function parseArgs(args: string[]): {
 
   if (!description) {
     throw new Error(
-      'Usage: tgt track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]'
+      'Usage: tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]'
     );
   }
 
@@ -69,7 +69,7 @@ export async function track(args: string[]) {
     const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
     const matches = projects.filter((p) => p.name.toLowerCase() === projectName.toLowerCase());
     if (matches.length === 0) {
-      console.error(`Project "${projectName}" not found. Use "tgt project-list" to list available projects.`);
+      console.error(`Project "${projectName}" not found. Use "tgp project-list" to list available projects.`);
       process.exit(1);
     }
     if (matches.length > 1) {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -18,5 +18,5 @@ function getVersion(): string {
 }
 
 export function version() {
-  console.log(`tgt v${getVersion()}`);
+  console.log(`tgp v${getVersion()}`);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { getConfigFile } from './paths.js';
 class ConfigNotFoundError extends Error {
   constructor() {
     super(
-      'No config found. Run: tgt auth <api-token>\n' +
+      'No config found. Run: tgp auth <api-token>\n' +
         'Or set TOGGL_API_TOKEN in your environment.\n' +
         'Get your token at https://track.toggl.com/profile'
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ if (command === 'auth') {
       projectRename(args);
       break;
     default:
-      console.error('Usage: tgt <command>');
+      console.error('Usage: tgp <command>');
       console.error(
         'Commands: auth, version, me, entry-list [-d DATE], project-list, project-rename <project_id> "New Name", entry-delete <entry_id>, track, stop, tag-list, entry-edit'
       );

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
-const APP_NAME = 'tgt';
+const APP_NAME = 'tgp';
 
 function isWindows(): boolean {
   return process.platform === 'win32';

--- a/tests/entry-delete.test.ts
+++ b/tests/entry-delete.test.ts
@@ -33,7 +33,7 @@ describe('entryDelete command', () => {
 
     await expect(entryDelete([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgt entry-delete <entry_id>');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp entry-delete <entry_id>');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();

--- a/tests/project-rename.test.ts
+++ b/tests/project-rename.test.ts
@@ -28,7 +28,7 @@ describe('projectRename command', () => {
 
     await expect(projectRename([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgt project-rename <project_id> "New Name"');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-rename <project_id> "New Name"');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
@@ -42,7 +42,7 @@ describe('projectRename command', () => {
 
     await expect(projectRename(['123'])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgt project-rename <project_id> "New Name"');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-rename <project_id> "New Name"');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();


### PR DESCRIPTION
## Summary

- Renames the CLI binary from `tgt` to `tgp` to align with the project name **toggl-pilot**
- Updates all 81 references across 28 files: core config (`package.json`, `src/paths.ts`), source files, tests, docs, and `AGENTS.md`

Closes #59