### PR TITLE
feat: add tag-rename command (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Run `tgp` without arguments to see all available commands.
 | `tgp project-list`                   | List workspace projects | [docs/project-list.md](docs/project-list.md)     |
 | `tgp project-rename <id> "New Name"` | Rename a project        | [docs/project-rename.md](docs/project-rename.md) |
 | `tgp tag-list`                       | List workspace tags     | [docs/tag-list.md](docs/tag-list.md)             |
+| `tgp tag-rename <id> "New Name"`     | Rename a tag            | [docs/tag-rename.md](docs/tag-rename.md)         |
 
 ## Configuration
 

--- a/docs/tag-rename.md
+++ b/docs/tag-rename.md
@@ -1,0 +1,28 @@
+# `tag-rename` — Rename a Tag
+
+Renames an existing tag in your workspace.
+
+## Usage
+
+```bash
+tgp tag-rename <tag_id> "New Name"
+```
+
+## Output
+
+```text
+Tag 1234567890 renamed to "New Name"
+```
+
+## Arguments
+
+| Argument     | Description            |
+| ------------ | ---------------------- |
+| `tag_id`     | Toggl tag ID to rename |
+| `"New Name"` | New name for the tag   |
+
+## Examples
+
+```bash
+tgp tag-rename 1234567890 "Backend"
+```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "project-rename": "tsx src/index.ts project-rename",
     "entry-delete": "tsx src/index.ts entry-delete",
     "tag-list": "tsx src/index.ts tag-list",
+    "tag-rename": "tsx src/index.ts tag-rename",
     "entry-edit": "tsx src/index.ts entry-edit",
     "stop": "tsx src/index.ts stop",
     "format": "prettier --write \"**/*.{ts,md,mdx}\"",

--- a/src/commands/tag-rename.ts
+++ b/src/commands/tag-rename.ts
@@ -1,0 +1,38 @@
+import { config } from '../config.js';
+import { put } from '../api.js';
+
+interface Tag {
+  id: number;
+  name: string;
+}
+
+export async function tagRename(args: string[]) {
+  const tagId = args[0];
+  const newName = args[1];
+
+  if (!tagId || !newName) {
+    console.error('Usage: tgp tag-rename <tag_id> "New Name"');
+    process.exit(1);
+  }
+
+  if (isNaN(Number(tagId))) {
+    console.error(`Invalid tag ID: "${tagId}". Must be a number.`);
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    const updated = await put<Tag>(`/workspaces/${wsId}/tags/${tagId}`, {
+      name: newName,
+    });
+    console.log(`Tag ${updated.id} renamed to "${updated.name}"`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Tag ${tagId} not found.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
+import { tagRename } from './commands/tag-rename.js';
 import { entryEdit } from './commands/entry-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { auth } from './commands/auth.js';
@@ -58,6 +59,9 @@ if (command === 'auth') {
     case 'tag-list':
       tagList();
       break;
+    case 'tag-rename':
+      tagRename(args);
+      break;
     case 'entry-edit':
       entryEdit(args);
       break;
@@ -67,7 +71,7 @@ if (command === 'auth') {
     default:
       console.error('Usage: tgp <command>');
       console.error(
-        'Commands: auth, version, me, entry-list [-d DATE], project-list, project-rename <project_id> "New Name", entry-delete <entry_id>, track, stop, tag-list, entry-edit'
+        'Commands: auth, version, me, entry-list [-d DATE], project-list, project-rename <project_id> "New Name", entry-delete <entry_id>, track, stop, tag-list, tag-rename <tag_id> "New Name", entry-edit'
       );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,11 @@ if (command === 'auth') {
     default:
       console.error('Usage: tgp <command>');
       console.error(
-        'Commands: auth, version, me, entry-list [-d DATE], project-list, project-rename <project_id> "New Name", entry-delete <entry_id>, track, stop, tag-list, tag-rename <tag_id> "New Name", entry-edit'
+        [
+          'Commands: auth, version, me,',
+          'track, stop, entry-edit, entry-list [-d DATE], entry-delete <entry_id>,',
+          'project-list, project-rename <project_id> "New Name", tag-list, tag-rename <tag_id> "New Name"',
+        ].join('\n')
       );
   }
 }


### PR DESCRIPTION
## Summary

- Add `tgp tag-rename <tag_id> "New Name"` command to rename an existing tag in the workspace
- Implements `PUT /workspaces/{workspace_id}/tags/{tag_id}` API endpoint
- Includes command implementation, docs, package.json script, and README table entry

Closes #22