### PR TITLE
feat: add tag-delete command (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Run `tgp` without arguments to see all available commands.
 | `tgp project-rename <id> "New Name"` | Rename a project        | [docs/project-rename.md](docs/project-rename.md) |
 | `tgp tag-list`                       | List workspace tags     | [docs/tag-list.md](docs/tag-list.md)             |
 | `tgp tag-rename <id> "New Name"`     | Rename a tag            | [docs/tag-rename.md](docs/tag-rename.md)         |
+| `tgp tag-delete <id>`                | Delete a tag            | [docs/tag-delete.md](docs/tag-delete.md)         |
 
 ## Configuration
 

--- a/docs/tag-delete.md
+++ b/docs/tag-delete.md
@@ -1,0 +1,36 @@
+# `tag-delete` — Delete a Tag
+
+Deletes a tag from your workspace. Find the tag ID using `tgp tag-list`.
+
+## Usage
+
+```bash
+tgp tag-delete <tag_id>
+```
+
+## Output
+
+```text
+Tag 1234567890 deleted.
+```
+
+## Arguments
+
+| Argument | Description            |
+| -------- | ---------------------- |
+| `tag_id` | Toggl tag ID to delete |
+
+## Examples
+
+```bash
+tgp tag-list
+#   1234567890   Backend
+#   9876543210   Frontend
+
+tgp tag-delete 1234567890
+#   Tag 1234567890 deleted.
+```
+
+## Errors
+
+- `Tag <id> not found.` — tag does not exist in the workspace

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "entry-delete": "tsx src/index.ts entry-delete",
     "tag-list": "tsx src/index.ts tag-list",
     "tag-rename": "tsx src/index.ts tag-rename",
+    "tag-delete": "tsx src/index.ts tag-delete",
     "entry-edit": "tsx src/index.ts entry-edit",
     "stop": "tsx src/index.ts stop",
     "format": "prettier --write \"**/*.{ts,md,mdx}\"",

--- a/src/commands/tag-delete.ts
+++ b/src/commands/tag-delete.ts
@@ -1,0 +1,30 @@
+import { config } from '../config.js';
+import { del } from '../api.js';
+
+export async function tagDelete(args: string[]) {
+  const tagId = args[0];
+
+  if (!tagId) {
+    console.error('Usage: tgp tag-delete <tag_id>');
+    process.exit(1);
+  }
+
+  if (isNaN(Number(tagId))) {
+    console.error(`Invalid tag ID: "${tagId}". Must be a number.`);
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    await del(`/workspaces/${wsId}/tags/${tagId}`);
+    console.log(`Tag ${tagId} deleted.`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Tag ${tagId} not found.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
 import { tagRename } from './commands/tag-rename.js';
+import { tagDelete } from './commands/tag-delete.js';
 import { entryEdit } from './commands/entry-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { auth } from './commands/auth.js';
@@ -62,6 +63,9 @@ if (command === 'auth') {
     case 'tag-rename':
       tagRename(args);
       break;
+    case 'tag-delete':
+      tagDelete(args);
+      break;
     case 'entry-edit':
       entryEdit(args);
       break;
@@ -74,7 +78,7 @@ if (command === 'auth') {
         [
           'Commands: auth, version, me,',
           'track, stop, entry-edit, entry-list [-d DATE], entry-delete <entry_id>,',
-          'project-list, project-rename <project_id> "New Name", tag-list, tag-rename <tag_id> "New Name"',
+          'project-list, project-rename <project_id> "New Name", tag-list, tag-rename <tag_id> "New Name", tag-delete <tag_id>',
         ].join('\n')
       );
   }


### PR DESCRIPTION
## Summary

- Add `tag-delete` command to delete a tag from the workspace via `DELETE /workspaces/{workspace_id}/tags/{tag_id}`
- Creates `src/commands/tag-delete.ts`, updates router, package.json script, docs, and README

Closes #23