### PR TITLE
feat: add tag-create command (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Run `tgp` without arguments to see all available commands.
 | `tgp project-list`                   | List workspace projects | [docs/project-list.md](docs/project-list.md)     |
 | `tgp project-rename <id> "New Name"` | Rename a project        | [docs/project-rename.md](docs/project-rename.md) |
 | `tgp tag-list`                       | List workspace tags     | [docs/tag-list.md](docs/tag-list.md)             |
+| `tgp tag-create "Tag Name"`          | Create a tag            | [docs/tag-create.md](docs/tag-create.md)         |
 | `tgp tag-rename <id> "New Name"`     | Rename a tag            | [docs/tag-rename.md](docs/tag-rename.md)         |
 | `tgp tag-delete <id>`                | Delete a tag            | [docs/tag-delete.md](docs/tag-delete.md)         |
 

--- a/docs/tag-create.md
+++ b/docs/tag-create.md
@@ -1,0 +1,27 @@
+# `tag-create` -- Create a Tag
+
+Creates a new tag in your workspace.
+
+## Usage
+
+```bash
+tgp tag-create "Tag Name"
+```
+
+## Output
+
+```text
+Tag 1234567890 created: "Tag Name"
+```
+
+## Arguments
+
+| Argument     | Description          |
+| ------------ | -------------------- |
+| `"Tag Name"` | Name for the new tag |
+
+## Examples
+
+```bash
+tgp tag-create "Backend"
+```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "project-rename": "tsx src/index.ts project-rename",
     "entry-delete": "tsx src/index.ts entry-delete",
     "tag-list": "tsx src/index.ts tag-list",
+    "tag-create": "tsx src/index.ts tag-create",
     "tag-rename": "tsx src/index.ts tag-rename",
     "tag-delete": "tsx src/index.ts tag-delete",
     "entry-edit": "tsx src/index.ts entry-edit",

--- a/src/commands/tag-create.ts
+++ b/src/commands/tag-create.ts
@@ -1,0 +1,33 @@
+import { config } from '../config.js';
+import { post } from '../api.js';
+
+interface Tag {
+  id: number;
+  name: string;
+}
+
+export async function tagCreate(args: string[]) {
+  const name = args[0];
+
+  if (!name) {
+    console.error('Usage: tgp tag-create "Tag Name"');
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    const tag = await post<Tag>(`/workspaces/${wsId}/tags`, {
+      name,
+      workspace_id: wsId,
+    });
+    console.log(`Tag ${tag.id} created: "${tag.name}"`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('400')) {
+      console.error(`Tag "${name}" already exists or is invalid.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
+import { tagCreate } from './commands/tag-create.js';
 import { tagRename } from './commands/tag-rename.js';
 import { tagDelete } from './commands/tag-delete.js';
-import { tagCreate } from './commands/tag-create.js';
 import { entryEdit } from './commands/entry-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { auth } from './commands/auth.js';
@@ -61,14 +61,14 @@ if (command === 'auth') {
     case 'tag-list':
       tagList();
       break;
+    case 'tag-create':
+      tagCreate(args);
+      break;
     case 'tag-rename':
       tagRename(args);
       break;
     case 'tag-delete':
       tagDelete(args);
-      break;
-    case 'tag-create':
-      tagCreate(args);
       break;
     case 'entry-edit':
       entryEdit(args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { stop } from './commands/stop.js';
 import { tagList } from './commands/tag-list.js';
 import { tagRename } from './commands/tag-rename.js';
 import { tagDelete } from './commands/tag-delete.js';
+import { tagCreate } from './commands/tag-create.js';
 import { entryEdit } from './commands/entry-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { auth } from './commands/auth.js';
@@ -66,6 +67,9 @@ if (command === 'auth') {
     case 'tag-delete':
       tagDelete(args);
       break;
+    case 'tag-create':
+      tagCreate(args);
+      break;
     case 'entry-edit':
       entryEdit(args);
       break;
@@ -78,7 +82,7 @@ if (command === 'auth') {
         [
           'Commands: auth, version, me,',
           'track, stop, entry-edit, entry-list [-d DATE], entry-delete <entry_id>,',
-          'project-list, project-rename <project_id> "New Name", tag-list, tag-rename <tag_id> "New Name", tag-delete <tag_id>',
+          'project-list, project-rename <project_id> "New Name", tag-list, tag-create "Tag Name", tag-rename <tag_id> "New Name", tag-delete <tag_id>',
         ].join('\n')
       );
   }


### PR DESCRIPTION
## Summary

- Add `tgp tag-create "Tag Name"` command to create tags in the workspace
- Uses `POST /workspaces/{workspace_id}/tags` API endpoint
- Includes error handling for duplicate/invalid tag names

Closes #83