### PR TITLE
test: add unit tests for tag commands (#86)

### DIFF
--- a/tests/tag-create.test.ts
+++ b/tests/tag-create.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  post: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { post } from '../src/api.js';
+import { tagCreate } from '../src/commands/tag-create.js';
+
+const mockedPost = vi.mocked(post);
+
+describe('tagCreate command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no name provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(tagCreate([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp tag-create "Tag Name"');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('creates tag and prints confirmation', async () => {
+    mockedPost.mockResolvedValue({ id: 456, name: 'Bug' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await tagCreate(['Bug']);
+
+    expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/tags', {
+      name: 'Bug',
+      workspace_id: 123,
+    });
+    expect(logSpy).toHaveBeenCalledWith('Tag 456 created: "Bug"');
+    logSpy.mockRestore();
+  });
+
+  it('handles 400 error (duplicate/invalid name)', async () => {
+    mockedPost.mockRejectedValue(new Error('Toggl API 400: Bad Request'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await tagCreate(['Bug']);
+
+    expect(logSpy).toHaveBeenCalledWith('Tag "Bug" already exists or is invalid.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-400 errors', async () => {
+    mockedPost.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(tagCreate(['Bug'])).rejects.toThrow('500');
+  });
+});

--- a/tests/tag-delete.test.ts
+++ b/tests/tag-delete.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  del: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { del } from '../src/api.js';
+import { tagDelete } from '../src/commands/tag-delete.js';
+
+const mockedDel = vi.mocked(del);
+
+describe('tagDelete command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(tagDelete([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp tag-delete <tag_id>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits on non-numeric tag ID', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(tagDelete(['abc'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Invalid tag ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('deletes tag and prints confirmation', async () => {
+    mockedDel.mockResolvedValue(undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await tagDelete(['456']);
+
+    expect(mockedDel).toHaveBeenCalledWith('/workspaces/123/tags/456');
+    expect(logSpy).toHaveBeenCalledWith('Tag 456 deleted.');
+    logSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedDel.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await tagDelete(['999']);
+
+    expect(logSpy).toHaveBeenCalledWith('Tag 999 not found.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedDel.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(tagDelete(['123'])).rejects.toThrow('500');
+  });
+});

--- a/tests/tag-rename.test.ts
+++ b/tests/tag-rename.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  put: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { put } from '../src/api.js';
+import { tagRename } from '../src/commands/tag-rename.js';
+
+const mockedPut = vi.mocked(put);
+
+describe('tagRename command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no args provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(tagRename([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp tag-rename <tag_id> "New Name"');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits with usage message when only ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(tagRename(['123'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp tag-rename <tag_id> "New Name"');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits on non-numeric tag ID', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(tagRename(['abc', 'New'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Invalid tag ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('renames tag and prints confirmation', async () => {
+    mockedPut.mockResolvedValue({ id: 456, name: 'Feature' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await tagRename(['456', 'Feature']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/tags/456', {
+      name: 'Feature',
+    });
+    expect(logSpy).toHaveBeenCalledWith('Tag 456 renamed to "Feature"');
+    logSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await tagRename(['999', 'New']);
+
+    expect(logSpy).toHaveBeenCalledWith('Tag 999 not found.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(tagRename(['123', 'New'])).rejects.toThrow('500');
+  });
+});


### PR DESCRIPTION
Closes #86

Add unit tests for the three tag commands with no existing test coverage.

**Tests added (15 total):**
- `tag-create` (4 tests): usage validation, success confirmation, 400 error handling, non-400 re-throw
- `tag-rename` (6 tests): usage validation (no args, ID only), non-numeric ID, success confirmation, 404 handling, non-404 re-throw
- `tag-delete` (5 tests): usage validation, non-numeric ID, success confirmation, 404 handling, non-404 re-throw

Follows the established pattern from `project-rename.test.ts` and `entry-delete.test.ts`.