### PR TITLE
fix: set active=true when creating projects

### DIFF
--- a/src/commands/project-create.ts
+++ b/src/commands/project-create.ts
@@ -76,6 +76,7 @@ export async function projectCreate(args: string[]) {
   const body: Record<string, unknown> = {
     name,
     workspace_id: wsId,
+    active: true,
     is_private: !isPublic,
   };
 

--- a/tests/project-create.test.ts
+++ b/tests/project-create.test.ts
@@ -47,6 +47,7 @@ describe('projectCreate command', () => {
     expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/projects', {
       name: 'New Project',
       workspace_id: 123,
+      active: true,
       is_private: true,
     });
     expect(logSpy).toHaveBeenCalledWith('Project 100 created: "New Project"');
@@ -62,6 +63,7 @@ describe('projectCreate command', () => {
     expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/projects', {
       name: 'Open Project',
       workspace_id: 123,
+      active: true,
       is_private: false,
     });
     logSpy.mockRestore();
@@ -76,6 +78,7 @@ describe('projectCreate command', () => {
     expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/projects', {
       name: 'Colored',
       workspace_id: 123,
+      active: true,
       is_private: true,
       color: '#0b83d9',
     });
@@ -93,6 +96,7 @@ describe('projectCreate command', () => {
     expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/projects', {
       name: 'Big Project',
       workspace_id: 123,
+      active: true,
       is_private: true,
       client_id: 50,
     });
@@ -110,6 +114,7 @@ describe('projectCreate command', () => {
     expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/projects', {
       name: 'Direct ID',
       workspace_id: 123,
+      active: true,
       is_private: true,
       client_id: 99,
     });
@@ -137,6 +142,7 @@ describe('projectCreate command', () => {
     expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/projects', {
       name: 'Full',
       workspace_id: 123,
+      active: true,
       is_private: false,
       client_id: 50,
       color: '#ff0000',


### PR DESCRIPTION
## Summary

- Projects created via `project-create` were archived by default because the Toggl API defaults `active` to `false` when not explicitly set
- Added `active: true` to the request body so new projects are created as active