### PR TITLE
feat: add project-delete command (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Coming soon — `client-list`, `client-add`, `client-rename`, `client-delete`.
 | `tgp project-list`               | List workspace projects | [docs/project-list.md](docs/project-list.md)     |
 | `tgp project-create`             | Create a project        | [docs/project-create.md](docs/project-create.md) |
 | `tgp project-rename <id> <name>` | Rename a project        | [docs/project-rename.md](docs/project-rename.md) |
+| `tgp project-delete <id>`        | Delete a project        | [docs/project-delete.md](docs/project-delete.md) |
 
 ### Tags
 

--- a/docs/project-delete.md
+++ b/docs/project-delete.md
@@ -1,0 +1,36 @@
+# `project-delete` — Delete a Project
+
+Deletes a project from your workspace. Find the project ID using `tgp project-list`.
+
+## Usage
+
+```bash
+tgp project-delete <project_id>
+```
+
+## Output
+
+```text
+Project 1234567890 deleted.
+```
+
+## Arguments
+
+| Argument     | Description                |
+| ------------ | -------------------------- |
+| `project_id` | Toggl project ID to delete |
+
+## Examples
+
+```bash
+tgp project-list
+#   1234567890   Backend
+#   9876543210   Frontend
+
+tgp project-delete 1234567890
+#   Project 1234567890 deleted.
+```
+
+## Errors
+
+- `Project <id> not found.` — project does not exist in the workspace

--- a/src/commands/project-delete.ts
+++ b/src/commands/project-delete.ts
@@ -1,0 +1,30 @@
+import { config } from '../config.js';
+import { del } from '../api.js';
+
+export async function projectDelete(args: string[]) {
+  const projectId = args[0];
+
+  if (!projectId) {
+    console.error('Usage: tgp project-delete <project_id>');
+    process.exit(1);
+  }
+
+  if (isNaN(Number(projectId))) {
+    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    await del(`/workspaces/${wsId}/projects/${projectId}`);
+    console.log(`Project ${projectId} deleted.`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Project ${projectId} not found.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { tagDelete } from './commands/tag-delete.js';
 import { entryEdit } from './commands/entry-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { projectCreate } from './commands/project-create.js';
+import { projectDelete } from './commands/project-delete.js';
 import { auth } from './commands/auth.js';
 import { version } from './commands/version.js';
 
@@ -80,12 +81,15 @@ if (command === 'auth') {
     case 'project-rename':
       projectRename(args);
       break;
+    case 'project-delete':
+      projectDelete(args);
+      break;
     default:
       console.error('Usage: tgp <command>');
       console.error('Commands:');
       console.error('  auth           version         me');
       console.error('  track          stop            entry-edit      entry-list      entry-delete');
-      console.error('  project-list   project-create  project-rename');
+      console.error('  project-list   project-create  project-rename  project-delete');
       console.error('  tag-list       tag-create      tag-rename      tag-delete');
   }
 }

--- a/tests/project-delete.test.ts
+++ b/tests/project-delete.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  del: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { del } from '../src/api.js';
+import { projectDelete } from '../src/commands/project-delete.js';
+
+const mockedDel = vi.mocked(del);
+
+describe('projectDelete command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectDelete([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-delete <project_id>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits on non-numeric project ID', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectDelete(['abc'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('deletes project and prints confirmation', async () => {
+    mockedDel.mockResolvedValue(undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectDelete(['456']);
+
+    expect(mockedDel).toHaveBeenCalledWith('/workspaces/123/projects/456');
+    expect(logSpy).toHaveBeenCalledWith('Project 456 deleted.');
+    logSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedDel.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await projectDelete(['999']);
+
+    expect(logSpy).toHaveBeenCalledWith('Project 999 not found.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedDel.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(projectDelete(['123'])).rejects.toThrow('500');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tgp project-delete <project_id>` command to delete a project from the current workspace
- Includes command implementation, tests (5 cases), docs page, and README update
- Follows the existing `tag-delete` pattern