### PR TITLE
feat: add --dur flag to entry-edit (#107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Run `tgp` without arguments to see all available commands.
 | --------------------------------------- | --------------------------- | -------------------------------------------- |
 | `tgp track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
 | `tgp stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
-| `tgp entry-edit <id> -d/-p/-t`          | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
+| `tgp entry-edit <id> -d/-p/-t/--dur`    | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
 | `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
 | `tgp entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |
 

--- a/docs/entry-edit.md
+++ b/docs/entry-edit.md
@@ -1,12 +1,13 @@
 # `entry-edit` — Edit a Time Entry
 
-Edit the description, project, or tags of an existing time entry. Preserves the timer
-state — running entries stay running, stopped entries stay stopped.
+Edit the description, project, tags, or duration of an existing time entry. Preserves the timer
+state — running entries stay running, stopped entries stay stopped. When editing duration,
+the start time stays fixed and the end time is recomputed.
 
 ## Usage
 
 ```bash
-tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2]
+tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2] [--dur 1h30m]
 ```
 
 ## Examples
@@ -15,16 +16,19 @@ tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,ta
 tgp entry-edit 4383745312 -d "Updated description"
 tgp entry-edit 4383745312 -p "Dev-Pilot"
 tgp entry-edit 4383745312 -t dev,review
+tgp entry-edit 4383745312 --dur 1h30m
 tgp entry-edit 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
+tgp entry-edit 4383745312 -d "Fixed typo" --dur 45m
 ```
 
 ## Options
 
-| Flag            | Short | Description                         |
-| --------------- | ----- | ----------------------------------- |
-| `--description` | `-d`  | New description                     |
-| `--project`     | `-p`  | New project name (case-insensitive) |
-| `--tags`        | `-t`  | New tags (replaces existing)        |
+| Flag            | Short | Description                              |
+| --------------- | ----- | ---------------------------------------- |
+| `--description` | `-d`  | New description                          |
+| `--project`     | `-p`  | New project name (case-insensitive)      |
+| `--tags`        | `-t`  | New tags (replaces existing)             |
+| `--dur`         |       | New duration (e.g. `1h30m`, `2h`, `45m`) |
 
 You must provide at least one option. Find the entry ID using `tgp entry-list`.
 

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -46,8 +46,7 @@ export function parseArgs(args: string[]): {
     } else if ((args[i] === '-p' || args[i] === '--project') && args[i + 1]) {
       project = args[++i];
     } else if ((args[i] === '-t' || args[i] === '--tags') && args[i + 1]) {
-      tags = args[i + 1].split(',').map((t) => t.trim());
-      i++;
+      tags = args[++i].split(',').map((t) => t.trim());
     } else if (args[i] === '--dur' && args[i + 1]) {
       dur = args[++i];
     } else if (!args[i].startsWith('-') && !id) {
@@ -100,6 +99,10 @@ export async function entryEdit(args: string[]) {
   let newDuration = entry.duration;
   let newStop = entry.stop;
   if (dur) {
+    if (!entry.stop) {
+      console.error('Cannot change duration of a running timer. Stop it first with: tgp stop');
+      process.exit(1);
+    }
     newDuration = parseDuration(dur);
     newStop = new Date(new Date(entry.start).getTime() + newDuration * 1000).toISOString();
   }

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -1,5 +1,5 @@
 import { get, put } from '../api.js';
-import { parseOrExit } from '../utils.js';
+import { parseDuration, parseOrExit } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -19,22 +19,26 @@ interface Project {
   name: string;
 }
 
-const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '-d', '--description']);
+const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '-d', '--description', '--dur']);
 
 export function parseArgs(args: string[]): {
   id: string;
   description: string | null;
   project: string | null;
   tags: string[] | null;
+  dur: string | null;
 } {
   let id: string | null = null;
   let description: string | null = null;
   let project: string | null = null;
   let tags: string[] | null = null;
+  let dur: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('-') && !VALID_FLAGS.has(args[i])) {
-      throw new Error(`Unknown flag: ${args[i]}. Valid flags: -d/--description, -p/--project, -t/--tags`);
+      throw new Error(
+        `Unknown flag: ${args[i]}. Valid flags: -d/--description, -p/--project, -t/--tags, --dur`
+      );
     }
 
     if ((args[i] === '-d' || args[i] === '--description') && args[i + 1]) {
@@ -42,25 +46,30 @@ export function parseArgs(args: string[]): {
     } else if ((args[i] === '-p' || args[i] === '--project') && args[i + 1]) {
       project = args[++i];
     } else if ((args[i] === '-t' || args[i] === '--tags') && args[i + 1]) {
-      tags = args[++i].split(',').map((t) => t.trim());
+      tags = args[i + 1].split(',').map((t) => t.trim());
+      i++;
+    } else if (args[i] === '--dur' && args[i + 1]) {
+      dur = args[++i];
     } else if (!args[i].startsWith('-') && !id) {
       id = args[i];
     }
   }
 
   if (!id) {
-    throw new Error('Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2]');
+    throw new Error(
+      'Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2] [--dur 1h30m]'
+    );
   }
 
-  if (!description && !project && !tags) {
-    throw new Error('Nothing to edit. Provide at least one of: -d, -p, -t');
+  if (!description && !project && !tags && !dur) {
+    throw new Error('Nothing to edit. Provide at least one of: -d, -p, -t, --dur');
   }
 
-  return { id: id!, description, project, tags };
+  return { id: id!, description, project, tags, dur };
 }
 
 export async function entryEdit(args: string[]) {
-  const { id, description, project: projectName, tags: newTags } = parseOrExit(() => parseArgs(args));
+  const { id, description, project: projectName, tags: newTags, dur } = parseOrExit(() => parseArgs(args));
 
   let entry: TimeEntry;
   try {
@@ -88,11 +97,20 @@ export async function entryEdit(args: string[]) {
     projectId = matches[0].id;
   }
 
+  let newDuration = entry.duration;
+  let newStop = entry.stop;
+  if (dur) {
+    newDuration = parseDuration(dur);
+    newStop = new Date(new Date(entry.start).getTime() + newDuration * 1000).toISOString();
+  }
+
   const updated = await put<TimeEntry>(`/workspaces/${wsId}/time_entries/${entry.id}`, {
     ...entry,
     description: description ?? entry.description,
     project_id: projectId,
     tags: newTags ?? entry.tags,
+    duration: newDuration,
+    stop: newStop,
   });
 
   const projectLabel = updated.project_name ? ` [${updated.project_name}]` : '';

--- a/tests/entry-edit-parseArgs.test.ts
+++ b/tests/entry-edit-parseArgs.test.ts
@@ -9,6 +9,7 @@ describe('entry-edit parseArgs', () => {
       description: 'New description',
       project: null,
       tags: null,
+      dur: null,
     });
   });
 
@@ -30,6 +31,7 @@ describe('entry-edit parseArgs', () => {
       description: 'Updated',
       project: 'Project',
       tags: ['review'],
+      dur: null,
     });
   });
 
@@ -52,5 +54,16 @@ describe('entry-edit parseArgs', () => {
 
   it('throws on empty args', () => {
     expect(() => parseArgs([])).toThrow('Usage');
+  });
+
+  it('parses --dur', () => {
+    const result = parseArgs(['12345', '--dur', '1h30m']);
+    expect(result.dur).toBe('1h30m');
+  });
+
+  it('parses --dur with other flags', () => {
+    const result = parseArgs(['12345', '-d', 'Desc', '--dur', '45m']);
+    expect(result.description).toBe('Desc');
+    expect(result.dur).toBe('45m');
   });
 });

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -160,4 +160,21 @@ describe('entryEdit command', () => {
 
     await expect(entryEdit(['100', '--dur', 'abc'])).rejects.toThrow('Invalid duration: abc');
   });
+
+  it('rejects --dur on running timer', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry, stop: null, duration: -1 });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(entryEdit(['100', '--dur', '1h'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'Cannot change duration of a running timer. Stop it first with: tgp stop'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
 });

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -110,4 +110,54 @@ describe('entryEdit command', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
   });
+
+  it('edits duration only, recomputes stop from start', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry });
+    mockedPut.mockResolvedValue({
+      ...baseEntry,
+      duration: 7200,
+      stop: '2025-06-15T12:00:00Z',
+    });
+
+    await entryEdit(['100', '--dur', '2h']);
+
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        duration: 7200,
+        stop: '2025-06-15T12:00:00.000Z',
+        start: '2025-06-15T10:00:00Z',
+        description: 'Original',
+        project_id: 10,
+        tags: ['dev'],
+      })
+    );
+  });
+
+  it('edits duration combined with description', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry });
+    mockedPut.mockResolvedValue({
+      ...baseEntry,
+      description: 'New desc',
+      duration: 5400,
+      stop: '2025-06-15T11:30:00.000Z',
+    });
+
+    await entryEdit(['100', '-d', 'New desc', '--dur', '1h30m']);
+
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        description: 'New desc',
+        duration: 5400,
+        stop: '2025-06-15T11:30:00.000Z',
+      })
+    );
+  });
+
+  it('throws on invalid duration format', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry });
+
+    await expect(entryEdit(['100', '--dur', 'abc'])).rejects.toThrow('Invalid duration: abc');
+  });
 });


### PR DESCRIPTION
## Summary

- Add `--dur` flag to `entry-edit` command to change the duration of a time entry
- Start time stays fixed, stop time and duration are recomputed client-side
- Supports human-readable format: `1h30m`, `2h`, `45m`

Closes #107