### PR TITLE
feat: add week command for weekly summary by project (#109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Run `tgp` without arguments to see all available commands.
 | `tgp stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
 | `tgp entry-edit <id> -d/-p/-t/--dur`    | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
 | `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
+| `tgp week`                              | Weekly summary by project   | [docs/week.md](docs/week.md)                 |
 | `tgp entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |
 
 ### Clients

--- a/docs/week.md
+++ b/docs/week.md
@@ -1,0 +1,28 @@
+# `week` — Weekly Summary
+
+Shows project totals for the current week (Monday–Sunday).
+
+## Usage
+
+```bash
+tgp week
+```
+
+## Output
+
+```text
+Week 19 (May 05 – May 11)
+
+  Project Alpha    12h30m
+  Project Beta      8h15m
+  Internal          3h00m
+  ────────────────────
+  Total            23h45m
+```
+
+## Details
+
+- Weeks run Monday through Sunday
+- Displays ISO week number and date range
+- Running timers are included with a live-calculated duration
+- Entries without a project are excluded from per-project totals but included in the grand total

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -1,0 +1,101 @@
+import { config } from '../config.js';
+import { get } from '../api.js';
+import { formatDate, formatDuration } from '../utils.js';
+
+interface TimeEntry {
+  id: number;
+  description: string;
+  start: string;
+  stop: string | null;
+  duration: number;
+  project_id: number | null;
+  project_name: string | null;
+  tags: string[] | null;
+  workspace_id: number;
+}
+
+export function getWeekBounds(refDate: Date): { monday: Date; sunday: Date; weekNumber: number } {
+  const d = new Date(refDate);
+  d.setUTCHours(12, 0, 0, 0);
+  const dayOfWeek = d.getUTCDay();
+  const offsetToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const monday = new Date(d);
+  monday.setUTCDate(d.getUTCDate() + offsetToMonday);
+  const sunday = new Date(monday);
+  sunday.setUTCDate(monday.getUTCDate() + 6);
+  const weekNumber = getISOWeekNumber(monday);
+  return { monday, sunday, weekNumber };
+}
+
+function getISOWeekNumber(date: Date): number {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatShortDate(date: Date): string {
+  return `${MONTHS[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
+export async function week() {
+  const { monday, sunday, weekNumber } = getWeekBounds(new Date());
+  const startStr = formatDate(monday);
+  const endStr = formatDate(new Date(sunday.getTime() + 86400000));
+
+  const wsId = await config.getWorkspaceId();
+  const timeEntries = await get<TimeEntry[]>(`/me/time_entries?start_date=${startStr}&end_date=${endStr}`);
+
+  const projectIds = [...new Set(timeEntries.filter((e) => e.project_id).map((e) => e.project_id!))];
+  const projectMap = new Map<number, string>();
+  if (projectIds.length > 0) {
+    const projects = await get<{ id: number; name: string }[]>(`/workspaces/${wsId}/projects`);
+    for (const p of projects) {
+      if (projectIds.includes(p.id)) projectMap.set(p.id, p.name);
+    }
+  }
+
+  if (timeEntries.length === 0) {
+    console.log(
+      `No time entries for week ${weekNumber} (${formatShortDate(monday)} – ${formatShortDate(sunday)})`
+    );
+    return;
+  }
+
+  const totals = new Map<string, number>();
+  let grandTotal = 0;
+
+  for (const entry of timeEntries) {
+    const durationSec =
+      entry.duration < 0 ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000) : entry.duration;
+
+    const projectName = entry.project_id
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? '—')
+      : '—';
+
+    if (projectName !== '—') {
+      totals.set(projectName, (totals.get(projectName) ?? 0) + durationSec);
+    }
+    grandTotal += durationSec;
+  }
+
+  console.log(`\nWeek ${weekNumber} (${formatShortDate(monday)} – ${formatShortDate(sunday)})\n`);
+
+  if (totals.size > 0) {
+    const maxNameLen = Math.max(
+      [...totals.keys()].reduce((m, n) => Math.max(m, n.length), 0),
+      'Total'.length
+    );
+    for (const [name, secs] of totals) {
+      console.log(`  ${name.padEnd(maxNameLen + 2)}${formatDuration(secs)}`);
+    }
+    console.log(`  ${'─'.repeat(maxNameLen + 8)}`);
+    console.log(`  ${'Total'.padEnd(maxNameLen + 2)}${formatDuration(grandTotal)}`);
+  } else {
+    console.log(`  Total ${formatDuration(grandTotal)}`);
+  }
+  console.log();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { get } from './api.js';
 import { hasConfig, ConfigNotFoundError } from './config.js';
 import { entryList } from './commands/entry-list.js';
+import { week } from './commands/week.js';
 import { projectList } from './commands/project-list.js';
 import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
@@ -48,6 +49,9 @@ if (command === 'auth') {
     case 'entry-list':
       entryList(args);
       break;
+    case 'week':
+      week();
+      break;
     case 'project-list':
       projectList();
       break;
@@ -89,6 +93,7 @@ if (command === 'auth') {
       console.error('Commands:');
       console.error('  auth           version         me');
       console.error('  track          stop            entry-edit      entry-list      entry-delete');
+      console.error('  week');
       console.error('  project-list   project-create  project-rename  project-delete');
       console.error('  tag-list       tag-create      tag-rename      tag-delete');
   }

--- a/tests/week.test.ts
+++ b/tests/week.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { getWeekBounds } from '../src/commands/week.js';
+
+describe('getWeekBounds', () => {
+  it('returns same Monday when given a Monday', () => {
+    const mon = new Date('2026-05-04T08:00:00Z');
+    const { monday, sunday, weekNumber } = getWeekBounds(mon);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-05-04');
+    expect(sunday.toISOString().slice(0, 10)).toBe('2026-05-10');
+    expect(weekNumber).toBe(19);
+  });
+
+  it('returns correct Monday for a Wednesday', () => {
+    const wed = new Date('2026-05-06T15:30:00Z');
+    const { monday, sunday } = getWeekBounds(wed);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-05-04');
+    expect(sunday.toISOString().slice(0, 10)).toBe('2026-05-10');
+  });
+
+  it('returns correct Monday for a Sunday', () => {
+    const sun = new Date('2026-05-10T22:00:00Z');
+    const { monday, sunday } = getWeekBounds(sun);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-05-04');
+    expect(sunday.toISOString().slice(0, 10)).toBe('2026-05-10');
+  });
+
+  it('handles week spanning month boundary', () => {
+    const thu = new Date('2026-04-30T12:00:00Z');
+    const { monday, sunday } = getWeekBounds(thu);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-04-27');
+    expect(sunday.toISOString().slice(0, 10)).toBe('2026-05-03');
+  });
+
+  it('handles week spanning year boundary', () => {
+    const wed = new Date('2025-12-31T12:00:00Z');
+    const { monday, sunday, weekNumber } = getWeekBounds(wed);
+    expect(monday.toISOString().slice(0, 10)).toBe('2025-12-29');
+    expect(sunday.toISOString().slice(0, 10)).toBe('2026-01-04');
+    expect(weekNumber).toBe(1);
+  });
+
+  it('calculates correct week number for week 2', () => {
+    const mon = new Date('2026-01-05T12:00:00Z');
+    const { weekNumber } = getWeekBounds(mon);
+    expect(weekNumber).toBe(2);
+  });
+
+  it('does not mutate the input date', () => {
+    const input = new Date('2026-05-07T12:00:00Z');
+    const before = input.toISOString();
+    getWeekBounds(input);
+    expect(input.toISOString()).toBe(before);
+  });
+
+  it('normalizes time to noon UTC', () => {
+    const lateNight = new Date('2026-05-07T02:00:00Z');
+    const { monday } = getWeekBounds(lateNight);
+    expect(monday.toISOString()).toBe('2026-05-04T12:00:00.000Z');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tgp week` command showing project totals for the current week (Mon–Sun)
- Includes ISO week number and date range in header
- Handles running timers with live-calculated duration
- Adds `getWeekBounds()` with 8 unit tests covering edge cases (month/year boundaries, immutability, normalization)

Closes #109