### PR TITLE
feat: add date and relative week selection to week command (#112)

### DIFF
--- a/docs/week.md
+++ b/docs/week.md
@@ -1,6 +1,6 @@
 # `week` — Weekly Summary
 
-Shows project totals for the current week (Monday–Sunday) or a selected week.
+Shows project totals for any week (Monday–Sunday). Defaults to the current week.
 
 ## Usage
 

--- a/docs/week.md
+++ b/docs/week.md
@@ -1,12 +1,24 @@
 # `week` — Weekly Summary
 
-Shows project totals for the current week (Monday–Sunday).
+Shows project totals for the current week (Monday–Sunday) or a selected week.
 
 ## Usage
 
 ```bash
-tgp week
+tgp week                     # current week
+tgp week --week -1           # last week
+tgp week --week -3           # 3 weeks ago
+tgp week --date 2026-04-01   # week containing Apr 1
 ```
+
+### Flags
+
+| Flag                | Shorthand       | Description                                                        |
+| ------------------- | --------------- | ------------------------------------------------------------------ |
+| `--week N`          | `-w N`          | Relative week offset (0 = current, -1 = last, 2 = two weeks ahead) |
+| `--date YYYY-MM-DD` | `-d YYYY-MM-DD` | Show the week containing the given date                            |
+
+`--date` and `--week` are mutually exclusive.
 
 ## Output
 
@@ -16,7 +28,7 @@ Week 19 (May 05 – May 11)
   Project Alpha    12h30m
   Project Beta      8h15m
   Internal          3h00m
-  ────────────────────
+  ───────────────────────
   Total            23h45m
 ```
 

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { formatDate, formatDuration } from '../utils.js';
+import { formatDate, formatDuration, parseDateArg, parseOrExit } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -41,8 +41,44 @@ function formatShortDate(date: Date): string {
   return `${MONTHS[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, '0')}`;
 }
 
-export async function week() {
-  const { monday, sunday, weekNumber } = getWeekBounds(new Date());
+function findFlag(args: string[], ...flags: string[]): number {
+  for (const f of flags) {
+    const idx = args.indexOf(f);
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+export function parseWeekArgs(args: string[]): Date {
+  const dateIdx = findFlag(args, '--date', '-d');
+  const weekIdx = findFlag(args, '--week', '-w');
+
+  if (dateIdx !== -1 && weekIdx !== -1) {
+    throw new Error('Cannot use both --date and --week');
+  }
+
+  if (weekIdx !== -1) {
+    const val = args[weekIdx + 1];
+    if (!val) throw new Error('Missing value for --week');
+    const offset = parseInt(val, 10);
+    if (isNaN(offset)) throw new Error(`Invalid week: ${val}`);
+    const { monday: currentMonday } = getWeekBounds(new Date());
+    const targetMonday = new Date(currentMonday);
+    targetMonday.setUTCDate(currentMonday.getUTCDate() + offset * 7);
+    return targetMonday;
+  }
+
+  if (dateIdx !== -1) {
+    if (!args[dateIdx + 1]) throw new Error('Missing value for --date');
+    return parseDateArg(args);
+  }
+
+  return new Date();
+}
+
+export async function week(args: string[]) {
+  const refDate = parseOrExit(() => parseWeekArgs(args));
+  const { monday, sunday, weekNumber } = getWeekBounds(refDate);
   const startStr = formatDate(monday);
   const endStr = formatDate(new Date(sunday.getTime() + 86400000));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ if (command === 'auth') {
       entryList(args);
       break;
     case 'week':
-      week();
+      week(args);
       break;
     case 'project-list':
       projectList();

--- a/tests/week.test.ts
+++ b/tests/week.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getWeekBounds } from '../src/commands/week.js';
+import { getWeekBounds, parseWeekArgs } from '../src/commands/week.js';
 
 describe('getWeekBounds', () => {
   it('returns same Monday when given a Monday', () => {
@@ -56,5 +56,78 @@ describe('getWeekBounds', () => {
     const lateNight = new Date('2026-05-07T02:00:00Z');
     const { monday } = getWeekBounds(lateNight);
     expect(monday.toISOString()).toBe('2026-05-04T12:00:00.000Z');
+  });
+});
+
+describe('parseWeekArgs', () => {
+  it('returns current date when no flags provided', () => {
+    const result = parseWeekArgs([]);
+    const today = new Date();
+    expect(result.toISOString().slice(0, 10)).toBe(today.toISOString().slice(0, 10));
+  });
+
+  it('parses --date YYYY-MM-DD', () => {
+    const result = parseWeekArgs(['--date', '2026-04-01']);
+    const { monday } = getWeekBounds(result);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-03-30');
+  });
+
+  it('parses -d shorthand', () => {
+    const result = parseWeekArgs(['-d', '2026-04-01']);
+    const { monday } = getWeekBounds(result);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-03-30');
+  });
+
+  it('parses --week -1 (last week)', () => {
+    const result = parseWeekArgs(['--week', '-1']);
+    const { monday: resultMonday } = getWeekBounds(result);
+    const { monday: currentMonday } = getWeekBounds(new Date());
+    const expectedMonday = new Date(currentMonday);
+    expectedMonday.setUTCDate(currentMonday.getUTCDate() - 7);
+    expect(resultMonday.toISOString().slice(0, 10)).toBe(expectedMonday.toISOString().slice(0, 10));
+  });
+
+  it('parses --week 0 (same as current week)', () => {
+    const result = parseWeekArgs(['--week', '0']);
+    const { monday: resultMonday } = getWeekBounds(result);
+    const { monday: currentMonday } = getWeekBounds(new Date());
+    expect(resultMonday.toISOString().slice(0, 10)).toBe(currentMonday.toISOString().slice(0, 10));
+  });
+
+  it('parses -w -3 (3 weeks ago)', () => {
+    const result = parseWeekArgs(['-w', '-3']);
+    const { monday: resultMonday } = getWeekBounds(result);
+    const { monday: currentMonday } = getWeekBounds(new Date());
+    const expectedMonday = new Date(currentMonday);
+    expectedMonday.setUTCDate(currentMonday.getUTCDate() - 21);
+    expect(resultMonday.toISOString().slice(0, 10)).toBe(expectedMonday.toISOString().slice(0, 10));
+  });
+
+  it('parses --week 2 (future week)', () => {
+    const result = parseWeekArgs(['--week', '2']);
+    const { monday: resultMonday } = getWeekBounds(result);
+    const { monday: currentMonday } = getWeekBounds(new Date());
+    const expectedMonday = new Date(currentMonday);
+    expectedMonday.setUTCDate(currentMonday.getUTCDate() + 14);
+    expect(resultMonday.toISOString().slice(0, 10)).toBe(expectedMonday.toISOString().slice(0, 10));
+  });
+
+  it('throws when both --date and --week are provided', () => {
+    expect(() => parseWeekArgs(['--date', '2026-04-01', '--week', '-1'])).toThrow(
+      'Cannot use both --date and --week'
+    );
+  });
+
+  it('throws on invalid date', () => {
+    expect(() => parseWeekArgs(['-d', 'not-a-date'])).toThrow('Invalid date');
+  });
+
+  it('throws on non-integer --week value', () => {
+    expect(() => parseWeekArgs(['--week', 'abc'])).toThrow('Invalid week');
+  });
+
+  it('throws when --date or --week is missing its value', () => {
+    expect(() => parseWeekArgs(['--date'])).toThrow();
+    expect(() => parseWeekArgs(['--week'])).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Add `--date YYYY-MM-DD` / `-d` flag to show the week containing a specific date
- Add `--week N` / `-w` flag for relative week selection (0 = current, -1 = last, positive = future)
- `--date` and `--week` are mutually exclusive with clear error messages
- 11 new tests for `parseWeekArgs` covering happy paths and edge cases
- Updated docs with flag reference table and usage examples

Closes #112