### PR TITLE
feat: add verbose mode with daily breakdown matrix to week command (#111)

### DIFF
--- a/docs/week.md
+++ b/docs/week.md
@@ -45,7 +45,7 @@ Week 19 (May 05 – May 11)
                  Mon    Tue    Wed    Thu    Fri    Sat    Sun    Total
 Project Alpha   2h30m  3h00m  1h00m  2h00m  4h00m      -      -   12h30m
 Project Beta    1h15m  2h00m  3h00m      -  2h00m      -      -    8h15m
-(no project)        -  1h00m      -  1h30m      -      -      -    2h30m
+—                   -  1h00m      -  1h30m      -      -      -    2h30m
 ──────────────────────────────────────────────────────────────────────────
 Daily Total     3h45m  5h00m  4h00m  3h30m  7h30m      -      -   23h45m
 ```
@@ -56,5 +56,5 @@ Daily Total     3h45m  5h00m  4h00m  3h30m  7h30m      -      -   23h45m
 - Displays ISO week number and date range
 - Running timers are included with a live-calculated duration
 - Entries without a project are excluded from per-project totals but included in the grand total
-- In verbose mode, entries without a project appear as `(no project)` and are sorted last
+- In verbose mode, entries without a project appear as `—` and are sorted last
 - Column widths are calculated dynamically based on the widest value in each column

--- a/docs/week.md
+++ b/docs/week.md
@@ -9,6 +9,8 @@ tgp week                     # current week
 tgp week --week -1           # last week
 tgp week --week -3           # 3 weeks ago
 tgp week --date 2026-04-01   # week containing Apr 1
+tgp week --verbose           # current week with daily breakdown
+tgp week -v --week -1        # last week with daily breakdown
 ```
 
 ### Flags
@@ -17,19 +19,35 @@ tgp week --date 2026-04-01   # week containing Apr 1
 | ------------------- | --------------- | ------------------------------------------------------------------ |
 | `--week N`          | `-w N`          | Relative week offset (0 = current, -1 = last, 2 = two weeks ahead) |
 | `--date YYYY-MM-DD` | `-d YYYY-MM-DD` | Show the week containing the given date                            |
+| `--verbose`         | `-v`            | Show a per-day breakdown matrix for each project                   |
 
-`--date` and `--week` are mutually exclusive.
+`--date` and `--week` are mutually exclusive. `--verbose` can be combined with either.
 
 ## Output
+
+### Compact mode (default)
 
 ```text
 Week 19 (May 05 – May 11)
 
-  Project Alpha    12h30m
-  Project Beta      8h15m
-  Internal          3h00m
-  ───────────────────────
-  Total            23h45m
+Project Alpha   12h30m
+Project Beta     8h15m
+Internal         3h00m
+──────────────────────
+Total           23h45m
+```
+
+### Verbose mode (`--verbose` / `-v`)
+
+```text
+Week 19 (May 05 – May 11)
+
+                 Mon    Tue    Wed    Thu    Fri    Sat    Sun    Total
+Project Alpha   2h30m  3h00m  1h00m  2h00m  4h00m      -      -   12h30m
+Project Beta    1h15m  2h00m  3h00m      -  2h00m      -      -    8h15m
+(no project)        -  1h00m      -  1h30m      -      -      -    2h30m
+──────────────────────────────────────────────────────────────────────────
+Daily Total     3h45m  5h00m  4h00m  3h30m  7h30m      -      -   23h45m
 ```
 
 ## Details
@@ -38,3 +56,5 @@ Week 19 (May 05 – May 11)
 - Displays ISO week number and date range
 - Running timers are included with a live-calculated duration
 - Entries without a project are excluded from per-project totals but included in the grand total
+- In verbose mode, entries without a project appear as `(no project)` and are sorted last
+- Column widths are calculated dynamically based on the widest value in each column

--- a/src/commands/entry-list.ts
+++ b/src/commands/entry-list.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { formatDate, formatTime, formatDuration, parseDateArg, parseOrExit } from '../utils.js';
+import { formatDate, formatTime, formatDuration, parseDateArg, parseOrExit, NONE } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -45,7 +45,7 @@ export async function entryList(args: string[]) {
   const rows: { line: string; isRunning: boolean }[] = [];
 
   const tagColWidth = timeEntries.reduce((max, entry) => {
-    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : '—';
+    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : NONE;
     return Math.max(max, tagStr.length);
   }, 0);
 
@@ -64,14 +64,14 @@ export async function entryList(args: string[]) {
     const dur = formatDuration(durationSec);
 
     const projectName = entry.project_id
-      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? '—')
-      : '—';
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? NONE)
+      : NONE;
 
-    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : '—';
+    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : NONE;
     const line = `  ${id.padEnd(12)} ${start}-${stop.padEnd(5)}  ${dur.padEnd(7)} ${(entry.description || '(no description)').slice(0, 22).padEnd(22)} ${tagStr.padEnd(tagColWidth + 1)} ${projectName}${isRunning ? '  ● running' : ''}`;
     rows.push({ line, isRunning });
 
-    if (projectName !== '—') {
+    if (projectName !== NONE) {
       totals.set(projectName, (totals.get(projectName) ?? 0) + durationSec);
     }
     grandTotal += durationSec;

--- a/src/commands/entry-list.ts
+++ b/src/commands/entry-list.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { formatDate, formatTime, formatDuration, parseDateArg, parseOrExit, NONE } from '../utils.js';
+import { formatDate, formatTime, formatDuration, parseDateArg, parseOrExit, DASH } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -45,7 +45,7 @@ export async function entryList(args: string[]) {
   const rows: { line: string; isRunning: boolean }[] = [];
 
   const tagColWidth = timeEntries.reduce((max, entry) => {
-    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : NONE;
+    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : DASH;
     return Math.max(max, tagStr.length);
   }, 0);
 
@@ -64,14 +64,14 @@ export async function entryList(args: string[]) {
     const dur = formatDuration(durationSec);
 
     const projectName = entry.project_id
-      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? NONE)
-      : NONE;
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? DASH)
+      : DASH;
 
-    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : NONE;
+    const tagStr = entry.tags?.length ? `{${entry.tags.join(',')}}` : DASH;
     const line = `  ${id.padEnd(12)} ${start}-${stop.padEnd(5)}  ${dur.padEnd(7)} ${(entry.description || '(no description)').slice(0, 22).padEnd(22)} ${tagStr.padEnd(tagColWidth + 1)} ${projectName}${isRunning ? '  ● running' : ''}`;
     rows.push({ line, isRunning });
 
-    if (projectName !== NONE) {
+    if (projectName !== DASH) {
       totals.set(projectName, (totals.get(projectName) ?? 0) + durationSec);
     }
     grandTotal += durationSec;

--- a/src/commands/project-list.ts
+++ b/src/commands/project-list.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { NONE } from '../utils.js';
+import { DASH } from '../utils.js';
 
 interface Project {
   id: number;
@@ -27,7 +27,7 @@ export async function projectList() {
 
   for (const p of list) {
     const status = p.active ? 'active' : 'archived';
-    const client = p.client_name ?? NONE;
+    const client = p.client_name ?? DASH;
     const line = `  ${String(p.id).padEnd(12)} ${p.name.slice(0, 30).padEnd(30)} ${client.slice(0, 20).padEnd(20)} ${status}`;
     console.log(line);
   }

--- a/src/commands/project-list.ts
+++ b/src/commands/project-list.ts
@@ -1,5 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
+import { NONE } from '../utils.js';
 
 interface Project {
   id: number;
@@ -26,7 +27,7 @@ export async function projectList() {
 
   for (const p of list) {
     const status = p.active ? 'active' : 'archived';
-    const client = p.client_name ?? '—';
+    const client = p.client_name ?? NONE;
     const line = `  ${String(p.id).padEnd(12)} ${p.name.slice(0, 30).padEnd(30)} ${client.slice(0, 20).padEnd(20)} ${status}`;
     console.log(line);
   }

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { formatDate, formatDuration, parseDateArg, parseOrExit, NONE } from '../utils.js';
+import { formatDate, formatDuration, parseDateArg, parseOrExit, DASH } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -98,8 +98,8 @@ export function buildProjectDayMap(
       entry.duration < 0 ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000) : entry.duration;
     const dayIdx = getDayIndex(entry.start);
     const projectName = entry.project_id
-      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? NONE)
-      : NONE;
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? DASH)
+      : DASH;
     ensure(projectName);
     map.get(projectName)![dayIdx] += durationSec;
   }
@@ -130,8 +130,8 @@ export function renderVerboseMatrix(
   lines.push(`\nWeek ${weekNumber} (${formatShortDate(monday)} – ${formatShortDate(sunday)})\n`);
 
   const projectNames = [...projectDayMap.keys()].sort((a, b) => {
-    if (a === NONE) return 1;
-    if (b === NONE) return -1;
+    if (a === DASH) return 1;
+    if (b === DASH) return -1;
     return a.localeCompare(b);
   });
 
@@ -229,10 +229,10 @@ export async function week(args: string[]) {
       entry.duration < 0 ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000) : entry.duration;
 
     const projectName = entry.project_id
-      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? NONE)
-      : NONE;
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? DASH)
+      : DASH;
 
-    if (projectName !== NONE) {
+    if (projectName !== DASH) {
       totals.set(projectName, (totals.get(projectName) ?? 0) + durationSec);
     }
     grandTotal += durationSec;

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { formatDate, formatDuration, parseDateArg, parseOrExit } from '../utils.js';
+import { formatDate, formatDuration, parseDateArg, parseOrExit, NONE } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -98,8 +98,8 @@ export function buildProjectDayMap(
       entry.duration < 0 ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000) : entry.duration;
     const dayIdx = getDayIndex(entry.start);
     const projectName = entry.project_id
-      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? '(no project)')
-      : '(no project)';
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? NONE)
+      : NONE;
     ensure(projectName);
     map.get(projectName)![dayIdx] += durationSec;
   }
@@ -130,8 +130,8 @@ export function renderVerboseMatrix(
   lines.push(`\nWeek ${weekNumber} (${formatShortDate(monday)} – ${formatShortDate(sunday)})\n`);
 
   const projectNames = [...projectDayMap.keys()].sort((a, b) => {
-    if (a === '(no project)') return 1;
-    if (b === '(no project)') return -1;
+    if (a === NONE) return 1;
+    if (b === NONE) return -1;
     return a.localeCompare(b);
   });
 
@@ -229,10 +229,10 @@ export async function week(args: string[]) {
       entry.duration < 0 ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000) : entry.duration;
 
     const projectName = entry.project_id
-      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? '—')
-      : '—';
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? NONE)
+      : NONE;
 
-    if (projectName !== '—') {
+    if (projectName !== NONE) {
       totals.set(projectName, (totals.get(projectName) ?? 0) + durationSec);
     }
     grandTotal += durationSec;

--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -49,7 +49,8 @@ function findFlag(args: string[], ...flags: string[]): number {
   return -1;
 }
 
-export function parseWeekArgs(args: string[]): Date {
+export function parseWeekArgs(args: string[]): { refDate: Date; verbose: boolean } {
+  const verbose = findFlag(args, '--verbose', '-v') !== -1;
   const dateIdx = findFlag(args, '--date', '-d');
   const weekIdx = findFlag(args, '--week', '-w');
 
@@ -65,19 +66,132 @@ export function parseWeekArgs(args: string[]): Date {
     const { monday: currentMonday } = getWeekBounds(new Date());
     const targetMonday = new Date(currentMonday);
     targetMonday.setUTCDate(currentMonday.getUTCDate() + offset * 7);
-    return targetMonday;
+    return { refDate: targetMonday, verbose };
   }
 
   if (dateIdx !== -1) {
     if (!args[dateIdx + 1]) throw new Error('Missing value for --date');
-    return parseDateArg(args);
+    return { refDate: parseDateArg(args), verbose };
   }
 
-  return new Date();
+  return { refDate: new Date(), verbose };
+}
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function getDayIndex(isoStart: string): number {
+  const dow = new Date(isoStart).getUTCDay();
+  return dow === 0 ? 6 : dow - 1;
+}
+
+export function buildProjectDayMap(
+  entries: TimeEntry[],
+  projectMap: Map<number, string>
+): Map<string, number[]> {
+  const map = new Map<string, number[]>();
+  const ensure = (key: string) => {
+    if (!map.has(key)) map.set(key, [0, 0, 0, 0, 0, 0, 0]);
+  };
+
+  for (const entry of entries) {
+    const durationSec =
+      entry.duration < 0 ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000) : entry.duration;
+    const dayIdx = getDayIndex(entry.start);
+    const projectName = entry.project_id
+      ? (projectMap.get(entry.project_id) ?? entry.project_name ?? '(no project)')
+      : '(no project)';
+    ensure(projectName);
+    map.get(projectName)![dayIdx] += durationSec;
+  }
+
+  return map;
+}
+
+function padRight(s: string, width: number): string {
+  return s + ' '.repeat(Math.max(0, width - s.length));
+}
+
+function padLeft(s: string, width: number): string {
+  return ' '.repeat(Math.max(0, width - s.length)) + s;
+}
+
+function formatCell(seconds: number, width: number): string {
+  if (seconds === 0) return padLeft('-', width);
+  return padLeft(formatDuration(seconds), width);
+}
+
+export function renderVerboseMatrix(
+  projectDayMap: Map<string, number[]>,
+  monday: Date,
+  sunday: Date,
+  weekNumber: number
+): string {
+  const lines: string[] = [];
+  lines.push(`\nWeek ${weekNumber} (${formatShortDate(monday)} – ${formatShortDate(sunday)})\n`);
+
+  const projectNames = [...projectDayMap.keys()].sort((a, b) => {
+    if (a === '(no project)') return 1;
+    if (b === '(no project)') return -1;
+    return a.localeCompare(b);
+  });
+
+  const dailyTotals = [0, 0, 0, 0, 0, 0, 0];
+  for (const row of projectDayMap.values()) {
+    for (let i = 0; i < 7; i++) dailyTotals[i] += row[i];
+  }
+
+  const projectRowTotals = new Map<string, number>();
+  let grandTotal = 0;
+  for (const [name, row] of projectDayMap) {
+    const rowTotal = row.reduce((s, v) => s + v, 0);
+    projectRowTotals.set(name, rowTotal);
+    grandTotal += rowTotal;
+  }
+
+  const dayHeaders = [...DAY_LABELS, 'Total'];
+  const headerWidths = dayHeaders.map(() => 0);
+  for (let i = 0; i < 7; i++) {
+    headerWidths[i] = Math.max(dayHeaders[i].length, formatDuration(dailyTotals[i]).length);
+    for (const name of projectNames) {
+      const val = projectDayMap.get(name)![i];
+      const formatted = val === 0 ? '-' : formatDuration(val);
+      headerWidths[i] = Math.max(headerWidths[i], formatted.length);
+    }
+  }
+  headerWidths[7] = Math.max('Total'.length, formatDuration(grandTotal).length);
+  for (const name of projectNames) {
+    const t = projectRowTotals.get(name)!;
+    headerWidths[7] = Math.max(headerWidths[7], formatDuration(t).length);
+  }
+
+  const nameColWidth = Math.max(...projectNames.map((n) => n.length), 'Daily Total'.length);
+
+  const headerLine =
+    padRight('', nameColWidth + 2) + dayHeaders.map((h, i) => padLeft(h, headerWidths[i])).join('  ');
+  lines.push(headerLine);
+
+  for (const name of projectNames) {
+    const row = projectDayMap.get(name)!;
+    const rowTotal = projectRowTotals.get(name)!;
+    const parts = row.map((val, i) => formatCell(val, headerWidths[i]));
+    parts.push(formatCell(rowTotal, headerWidths[7]));
+    lines.push(padRight(name, nameColWidth + 2) + parts.join('  '));
+  }
+
+  const totalWidth =
+    nameColWidth + 2 + headerWidths.reduce((s, w) => s + w, 0) + (headerWidths.length - 1) * 2;
+  lines.push('─'.repeat(totalWidth));
+
+  const dailyParts = dailyTotals.map((val, i) => formatCell(val, headerWidths[i]));
+  dailyParts.push(formatCell(grandTotal, headerWidths[7]));
+  lines.push(padRight('Daily Total', nameColWidth + 2) + dailyParts.join('  '));
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 export async function week(args: string[]) {
-  const refDate = parseOrExit(() => parseWeekArgs(args));
+  const { refDate, verbose } = parseOrExit(() => parseWeekArgs(args));
   const { monday, sunday, weekNumber } = getWeekBounds(refDate);
   const startStr = formatDate(monday);
   const endStr = formatDate(new Date(sunday.getTime() + 86400000));
@@ -98,6 +212,12 @@ export async function week(args: string[]) {
     console.log(
       `No time entries for week ${weekNumber} (${formatShortDate(monday)} – ${formatShortDate(sunday)})`
     );
+    return;
+  }
+
+  if (verbose) {
+    const projectDayMap = buildProjectDayMap(timeEntries, projectMap);
+    console.log(renderVerboseMatrix(projectDayMap, monday, sunday, weekNumber));
     return;
   }
 
@@ -126,12 +246,12 @@ export async function week(args: string[]) {
       'Total'.length
     );
     for (const [name, secs] of totals) {
-      console.log(`  ${name.padEnd(maxNameLen + 2)}${formatDuration(secs)}`);
+      console.log(`${name.padEnd(maxNameLen + 2)}${formatDuration(secs)}`);
     }
-    console.log(`  ${'─'.repeat(maxNameLen + 8)}`);
-    console.log(`  ${'Total'.padEnd(maxNameLen + 2)}${formatDuration(grandTotal)}`);
+    console.log(`${'─'.repeat(maxNameLen + 6)}`);
+    console.log(`${'Total'.padEnd(maxNameLen + 2)}${formatDuration(grandTotal)}`);
   } else {
-    console.log(`  Total ${formatDuration(grandTotal)}`);
+    console.log(`Total ${formatDuration(grandTotal)}`);
   }
   console.log();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+export const NONE = '—';
+
 export function parseOrExit<T>(fn: () => T): T {
   try {
     return fn();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export const NONE = '—';
+export const DASH = '—';
 
 export function parseOrExit<T>(fn: () => T): T {
   try {

--- a/tests/week.test.ts
+++ b/tests/week.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getWeekBounds, parseWeekArgs } from '../src/commands/week.js';
+import {
+  getWeekBounds,
+  parseWeekArgs,
+  buildProjectDayMap,
+  renderVerboseMatrix,
+} from '../src/commands/week.js';
 
 describe('getWeekBounds', () => {
   it('returns same Monday when given a Monday', () => {
@@ -61,26 +66,26 @@ describe('getWeekBounds', () => {
 
 describe('parseWeekArgs', () => {
   it('returns current date when no flags provided', () => {
-    const result = parseWeekArgs([]);
+    const { refDate } = parseWeekArgs([]);
     const today = new Date();
-    expect(result.toISOString().slice(0, 10)).toBe(today.toISOString().slice(0, 10));
+    expect(refDate.toISOString().slice(0, 10)).toBe(today.toISOString().slice(0, 10));
   });
 
   it('parses --date YYYY-MM-DD', () => {
-    const result = parseWeekArgs(['--date', '2026-04-01']);
-    const { monday } = getWeekBounds(result);
+    const { refDate } = parseWeekArgs(['--date', '2026-04-01']);
+    const { monday } = getWeekBounds(refDate);
     expect(monday.toISOString().slice(0, 10)).toBe('2026-03-30');
   });
 
   it('parses -d shorthand', () => {
-    const result = parseWeekArgs(['-d', '2026-04-01']);
-    const { monday } = getWeekBounds(result);
+    const { refDate } = parseWeekArgs(['-d', '2026-04-01']);
+    const { monday } = getWeekBounds(refDate);
     expect(monday.toISOString().slice(0, 10)).toBe('2026-03-30');
   });
 
   it('parses --week -1 (last week)', () => {
-    const result = parseWeekArgs(['--week', '-1']);
-    const { monday: resultMonday } = getWeekBounds(result);
+    const { refDate } = parseWeekArgs(['--week', '-1']);
+    const { monday: resultMonday } = getWeekBounds(refDate);
     const { monday: currentMonday } = getWeekBounds(new Date());
     const expectedMonday = new Date(currentMonday);
     expectedMonday.setUTCDate(currentMonday.getUTCDate() - 7);
@@ -88,15 +93,15 @@ describe('parseWeekArgs', () => {
   });
 
   it('parses --week 0 (same as current week)', () => {
-    const result = parseWeekArgs(['--week', '0']);
-    const { monday: resultMonday } = getWeekBounds(result);
+    const { refDate } = parseWeekArgs(['--week', '0']);
+    const { monday: resultMonday } = getWeekBounds(refDate);
     const { monday: currentMonday } = getWeekBounds(new Date());
     expect(resultMonday.toISOString().slice(0, 10)).toBe(currentMonday.toISOString().slice(0, 10));
   });
 
   it('parses -w -3 (3 weeks ago)', () => {
-    const result = parseWeekArgs(['-w', '-3']);
-    const { monday: resultMonday } = getWeekBounds(result);
+    const { refDate } = parseWeekArgs(['-w', '-3']);
+    const { monday: resultMonday } = getWeekBounds(refDate);
     const { monday: currentMonday } = getWeekBounds(new Date());
     const expectedMonday = new Date(currentMonday);
     expectedMonday.setUTCDate(currentMonday.getUTCDate() - 21);
@@ -104,8 +109,8 @@ describe('parseWeekArgs', () => {
   });
 
   it('parses --week 2 (future week)', () => {
-    const result = parseWeekArgs(['--week', '2']);
-    const { monday: resultMonday } = getWeekBounds(result);
+    const { refDate } = parseWeekArgs(['--week', '2']);
+    const { monday: resultMonday } = getWeekBounds(refDate);
     const { monday: currentMonday } = getWeekBounds(new Date());
     const expectedMonday = new Date(currentMonday);
     expectedMonday.setUTCDate(currentMonday.getUTCDate() + 14);
@@ -130,4 +135,172 @@ describe('parseWeekArgs', () => {
     expect(() => parseWeekArgs(['--date'])).toThrow();
     expect(() => parseWeekArgs(['--week'])).toThrow();
   });
+
+  it('returns verbose=false by default', () => {
+    const { verbose } = parseWeekArgs([]);
+    expect(verbose).toBe(false);
+  });
+
+  it('parses --verbose flag', () => {
+    const { verbose } = parseWeekArgs(['--verbose']);
+    expect(verbose).toBe(true);
+  });
+
+  it('parses -v shorthand', () => {
+    const { verbose } = parseWeekArgs(['-v']);
+    expect(verbose).toBe(true);
+  });
+
+  it('combines --verbose with --date', () => {
+    const { refDate, verbose } = parseWeekArgs(['--verbose', '--date', '2026-04-01']);
+    const { monday } = getWeekBounds(refDate);
+    expect(monday.toISOString().slice(0, 10)).toBe('2026-03-30');
+    expect(verbose).toBe(true);
+  });
+
+  it('combines -v with --week', () => {
+    const { verbose } = parseWeekArgs(['-v', '--week', '-1']);
+    expect(verbose).toBe(true);
+  });
 });
+
+describe('buildProjectDayMap', () => {
+  it('groups entries by project and day', () => {
+    const entries = [
+      makeEntry(1, '2026-05-04T09:00:00Z', 3600, 10),
+      makeEntry(2, '2026-05-05T09:00:00Z', 7200, 10),
+      makeEntry(3, '2026-05-04T10:00:00Z', 1800, 20),
+    ];
+    const projectMap = new Map([
+      [10, 'Alpha'],
+      [20, 'Beta'],
+    ]);
+    const result = buildProjectDayMap(entries, projectMap);
+    expect(result.get('Alpha')![0]).toBe(3600);
+    expect(result.get('Alpha')![1]).toBe(7200);
+    expect(result.get('Beta')![0]).toBe(1800);
+  });
+
+  it('groups entries without project as (no project)', () => {
+    const entries = [makeEntry(1, '2026-05-04T09:00:00Z', 3600, null)];
+    const projectMap = new Map<number, string>();
+    const result = buildProjectDayMap(entries, projectMap);
+    expect(result.has('(no project)')).toBe(true);
+    expect(result.get('(no project)')![0]).toBe(3600);
+  });
+
+  it('maps Sunday to index 6', () => {
+    const entries = [makeEntry(1, '2026-05-10T09:00:00Z', 1800, 10)];
+    const projectMap = new Map([[10, 'Alpha']]);
+    const result = buildProjectDayMap(entries, projectMap);
+    expect(result.get('Alpha')![6]).toBe(1800);
+  });
+
+  it('maps Saturday to index 5', () => {
+    const entries = [makeEntry(1, '2026-05-09T09:00:00Z', 2400, 10)];
+    const projectMap = new Map([[10, 'Alpha']]);
+    const result = buildProjectDayMap(entries, projectMap);
+    expect(result.get('Alpha')![5]).toBe(2400);
+  });
+
+  it('handles running timer entries (negative duration)', () => {
+    const start = new Date(Date.now() - 1800000);
+    const entries = [makeEntry(1, start.toISOString(), -1, 10)];
+    const projectMap = new Map([[10, 'Alpha']]);
+    const result = buildProjectDayMap(entries, projectMap);
+    const dayIdx = start.getUTCDay() === 0 ? 6 : start.getUTCDay() - 1;
+    expect(result.get('Alpha')![dayIdx]).toBeGreaterThanOrEqual(1799);
+  });
+
+  it('returns empty map for empty entries', () => {
+    const result = buildProjectDayMap([], new Map());
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('renderVerboseMatrix', () => {
+  it('renders a basic matrix with one project', () => {
+    const projectDayMap = new Map<string, number[]>([['Alpha', [3600, 7200, 0, 0, 0, 0, 0]]]);
+    const monday = new Date('2026-05-04T12:00:00Z');
+    const sunday = new Date('2026-05-10T12:00:00Z');
+    const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
+
+    expect(output).toContain('Week 19 (May 04 – May 10)');
+    expect(output).toContain('Alpha');
+    expect(output).toContain('1h00m');
+    expect(output).toContain('2h00m');
+    expect(output).toContain('Daily Total');
+    expect(output).toContain('─');
+  });
+
+  it('shows - for empty cells', () => {
+    const projectDayMap = new Map<string, number[]>([['Alpha', [0, 0, 0, 0, 0, 0, 0]]]);
+    const monday = new Date('2026-05-04T12:00:00Z');
+    const sunday = new Date('2026-05-10T12:00:00Z');
+    const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
+
+    expect(output).toContain('-');
+  });
+
+  it('places (no project) row last', () => {
+    const projectDayMap = new Map<string, number[]>([
+      ['(no project)', [3600, 0, 0, 0, 0, 0, 0]],
+      ['Alpha', [1800, 0, 0, 0, 0, 0, 0]],
+    ]);
+    const monday = new Date('2026-05-04T12:00:00Z');
+    const sunday = new Date('2026-05-10T12:00:00Z');
+    const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
+    const alphaIdx = output.indexOf('Alpha');
+    const noProjIdx = output.indexOf('(no project)');
+    expect(noProjIdx).toBeGreaterThan(alphaIdx);
+  });
+
+  it('sorts project names alphabetically', () => {
+    const projectDayMap = new Map<string, number[]>([
+      ['Zeta', [3600, 0, 0, 0, 0, 0, 0]],
+      ['Alpha', [1800, 0, 0, 0, 0, 0, 0]],
+    ]);
+    const monday = new Date('2026-05-04T12:00:00Z');
+    const sunday = new Date('2026-05-10T12:00:00Z');
+    const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
+    const alphaIdx = output.indexOf('Alpha');
+    const zetaIdx = output.indexOf('Zeta');
+    expect(alphaIdx).toBeLessThan(zetaIdx);
+  });
+
+  it('computes Daily Total correctly', () => {
+    const projectDayMap = new Map<string, number[]>([
+      ['Alpha', [3600, 7200, 0, 0, 0, 0, 0]],
+      ['Beta', [1800, 3600, 0, 0, 0, 0, 0]],
+    ]);
+    const monday = new Date('2026-05-04T12:00:00Z');
+    const sunday = new Date('2026-05-10T12:00:00Z');
+    const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
+
+    expect(output).toContain('Daily Total');
+    expect(output).toContain('4h30m');
+  });
+
+  it('renders Total column per project', () => {
+    const projectDayMap = new Map<string, number[]>([['Alpha', [3600, 7200, 0, 0, 0, 0, 0]]]);
+    const monday = new Date('2026-05-04T12:00:00Z');
+    const sunday = new Date('2026-05-10T12:00:00Z');
+    const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
+
+    expect(output).toContain('3h00m');
+  });
+});
+
+function makeEntry(id: number, start: string, duration: number, project_id: number | null) {
+  return {
+    id,
+    description: '',
+    start,
+    stop: duration < 0 ? null : new Date(new Date(start).getTime() + duration * 1000).toISOString(),
+    duration,
+    project_id,
+    project_name: null,
+    tags: null,
+    workspace_id: 1,
+  };
+}

--- a/tests/week.test.ts
+++ b/tests/week.test.ts
@@ -5,6 +5,7 @@ import {
   buildProjectDayMap,
   renderVerboseMatrix,
 } from '../src/commands/week.js';
+import { NONE } from '../src/utils.js';
 
 describe('getWeekBounds', () => {
   it('returns same Monday when given a Monday', () => {
@@ -181,12 +182,12 @@ describe('buildProjectDayMap', () => {
     expect(result.get('Beta')![0]).toBe(1800);
   });
 
-  it('groups entries without project as (no project)', () => {
+  it('groups entries without project as —', () => {
     const entries = [makeEntry(1, '2026-05-04T09:00:00Z', 3600, null)];
     const projectMap = new Map<number, string>();
     const result = buildProjectDayMap(entries, projectMap);
-    expect(result.has('(no project)')).toBe(true);
-    expect(result.get('(no project)')![0]).toBe(3600);
+    expect(result.has(NONE)).toBe(true);
+    expect(result.get(NONE)![0]).toBe(3600);
   });
 
   it('maps Sunday to index 6', () => {
@@ -242,17 +243,17 @@ describe('renderVerboseMatrix', () => {
     expect(output).toContain('-');
   });
 
-  it('places (no project) row last', () => {
+  it('places — row last', () => {
     const projectDayMap = new Map<string, number[]>([
-      ['(no project)', [3600, 0, 0, 0, 0, 0, 0]],
+      [NONE, [3600, 0, 0, 0, 0, 0, 0]],
       ['Alpha', [1800, 0, 0, 0, 0, 0, 0]],
     ]);
     const monday = new Date('2026-05-04T12:00:00Z');
     const sunday = new Date('2026-05-10T12:00:00Z');
     const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
     const alphaIdx = output.indexOf('Alpha');
-    const noProjIdx = output.indexOf('(no project)');
-    expect(noProjIdx).toBeGreaterThan(alphaIdx);
+    const dashIdx = output.indexOf(NONE);
+    expect(dashIdx).toBeGreaterThan(alphaIdx);
   });
 
   it('sorts project names alphabetically', () => {

--- a/tests/week.test.ts
+++ b/tests/week.test.ts
@@ -5,7 +5,7 @@ import {
   buildProjectDayMap,
   renderVerboseMatrix,
 } from '../src/commands/week.js';
-import { NONE } from '../src/utils.js';
+import { DASH } from '../src/utils.js';
 
 describe('getWeekBounds', () => {
   it('returns same Monday when given a Monday', () => {
@@ -186,8 +186,8 @@ describe('buildProjectDayMap', () => {
     const entries = [makeEntry(1, '2026-05-04T09:00:00Z', 3600, null)];
     const projectMap = new Map<number, string>();
     const result = buildProjectDayMap(entries, projectMap);
-    expect(result.has(NONE)).toBe(true);
-    expect(result.get(NONE)![0]).toBe(3600);
+    expect(result.has(DASH)).toBe(true);
+    expect(result.get(DASH)![0]).toBe(3600);
   });
 
   it('maps Sunday to index 6', () => {
@@ -245,14 +245,14 @@ describe('renderVerboseMatrix', () => {
 
   it('places — row last', () => {
     const projectDayMap = new Map<string, number[]>([
-      [NONE, [3600, 0, 0, 0, 0, 0, 0]],
+      [DASH, [3600, 0, 0, 0, 0, 0, 0]],
       ['Alpha', [1800, 0, 0, 0, 0, 0, 0]],
     ]);
     const monday = new Date('2026-05-04T12:00:00Z');
     const sunday = new Date('2026-05-10T12:00:00Z');
     const output = renderVerboseMatrix(projectDayMap, monday, sunday, 19);
     const alphaIdx = output.indexOf('Alpha');
-    const dashIdx = output.indexOf(NONE);
+    const dashIdx = output.indexOf(DASH);
     expect(dashIdx).toBeGreaterThan(alphaIdx);
   });
 


### PR DESCRIPTION
## Summary

- Add `-v`/`--verbose` flag to `tgp week` that displays a project-per-day matrix
- Entries grouped by project name and day (Mon–Sun), with dynamic column widths
- `(no project)` entries shown as a separate row, sorted last
- Running timers included with live-calculated duration
- Remove 2-space indent from compact mode for consistency with verbose output

Closes #111