### PR TITLE
docs: reorder entries table to match list-first pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Run `tgp` without arguments to see all available commands.
 
 | Command                                 | Description                 | Docs                                         |
 | --------------------------------------- | --------------------------- | -------------------------------------------- |
+| `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
 | `tgp track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
 | `tgp stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
 | `tgp entry-edit <id> -d/-p/-t/--dur`    | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
-| `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
 | `tgp week`                              | Weekly summary by project   | [docs/week.md](docs/week.md)                 |
 | `tgp entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |
 


### PR DESCRIPTION
## Summary
- Reorder the Entries table in README to follow the same list-first, delete-last pattern used by Projects and Tags tables