### PR TITLE
fix: align durations and separator width in week summary (#118)

### DIFF
--- a/src/commands/week.ts
+++ b/src/commands/week.ts
@@ -245,11 +245,12 @@ export async function week(args: string[]) {
       [...totals.keys()].reduce((m, n) => Math.max(m, n.length), 0),
       'Total'.length
     );
+    const maxDurLen = Math.max(...[...totals.values(), grandTotal].map((s) => formatDuration(s).length));
     for (const [name, secs] of totals) {
-      console.log(`${name.padEnd(maxNameLen + 2)}${formatDuration(secs)}`);
+      console.log(`${name.padEnd(maxNameLen + 2)}${formatDuration(secs).padStart(maxDurLen)}`);
     }
-    console.log(`${'─'.repeat(maxNameLen + 6)}`);
-    console.log(`${'Total'.padEnd(maxNameLen + 2)}${formatDuration(grandTotal)}`);
+    console.log(`${'─'.repeat(maxNameLen + 2 + maxDurLen)}`);
+    console.log(`${'Total'.padEnd(maxNameLen + 2)}${formatDuration(grandTotal).padStart(maxDurLen)}`);
   } else {
     console.log(`Total ${formatDuration(grandTotal)}`);
   }


### PR DESCRIPTION
Fixes #118

- Right-align duration values so the `h` marker lines up across all rows (including total)
- Compute separator width from actual max name + duration length instead of hardcoded `+ 6`