### PR TITLE
fix: persist tag changes in entry-edit (#122)

### DIFF
--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -19,7 +19,63 @@ interface Project {
   name: string;
 }
 
+interface TimeEntryUpdate {
+  description: string;
+  project_id: number | null;
+  start: string;
+  stop: string | null;
+  duration: number;
+  workspace_id: number;
+  billable: boolean;
+  tags?: string[];
+}
+
 const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '-d', '--description', '--dur']);
+
+function normalizeTags(tags: string[] | null): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawTag of tags ?? []) {
+    const tag = rawTag.trim();
+    const key = tag.toLowerCase();
+
+    if (!tag || seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(tag);
+  }
+
+  return normalized;
+}
+
+function tagKey(tag: string): string {
+  return tag.toLowerCase();
+}
+
+function diffTags(source: string[], target: string[]): string[] {
+  const targetKeys = new Set(target.map(tagKey));
+  return source.filter((tag) => !targetKeys.has(tagKey(tag)));
+}
+
+function buildUpdateBody(
+  entry: TimeEntry,
+  description: string,
+  projectId: number | null,
+  duration: number,
+  stop: string | null,
+  tags?: string[]
+): TimeEntryUpdate {
+  return {
+    description,
+    project_id: projectId,
+    start: entry.start,
+    stop,
+    duration,
+    workspace_id: entry.workspace_id,
+    billable: entry.billable,
+    ...(tags !== undefined ? { tags } : {}),
+  };
+}
 
 export function parseArgs(args: string[]): {
   id: string;
@@ -45,8 +101,8 @@ export function parseArgs(args: string[]): {
       description = args[++i];
     } else if ((args[i] === '-p' || args[i] === '--project') && args[i + 1]) {
       project = args[++i];
-    } else if ((args[i] === '-t' || args[i] === '--tags') && args[i + 1]) {
-      tags = args[++i].split(',').map((t) => t.trim());
+    } else if ((args[i] === '-t' || args[i] === '--tags') && i + 1 < args.length) {
+      tags = normalizeTags(args[++i].split(','));
     } else if (args[i] === '--dur' && args[i + 1]) {
       dur = args[++i];
     } else if (!args[i].startsWith('-') && !id) {
@@ -107,14 +163,29 @@ export async function entryEdit(args: string[]) {
     newStop = new Date(new Date(entry.start).getTime() + newDuration * 1000).toISOString();
   }
 
-  const updated = await put<TimeEntry>(`/workspaces/${wsId}/time_entries/${entry.id}`, {
-    ...entry,
-    description: description ?? entry.description,
-    project_id: projectId,
-    tags: newTags ?? entry.tags,
-    duration: newDuration,
-    stop: newStop,
-  });
+  const nextDescription = description ?? entry.description;
+  const hasEntryChanges = description !== null || projectName !== null || dur !== null;
+  const hasTagChanges =
+    newTags !== null &&
+    (diffTags(normalizeTags(entry.tags), newTags).length > 0 ||
+      diffTags(newTags, normalizeTags(entry.tags)).length > 0);
+
+  let updated = entry;
+
+  if (hasEntryChanges || hasTagChanges) {
+    await put<TimeEntry>(
+      `/workspaces/${wsId}/time_entries/${entry.id}`,
+      buildUpdateBody(
+        entry,
+        nextDescription,
+        projectId,
+        newDuration,
+        newStop,
+        newTags !== null ? newTags : undefined
+      )
+    );
+    updated = await get<TimeEntry>(`/me/time_entries/${id}`);
+  }
 
   const projectLabel = updated.project_name ? ` [${updated.project_name}]` : '';
   const tagLabel = updated.tags?.length ? ` {${updated.tags.join(', ')}}` : '';

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -173,7 +173,7 @@ export async function entryEdit(args: string[]) {
   let updated = entry;
 
   if (hasEntryChanges || hasTagChanges) {
-    await put<TimeEntry>(
+    updated = await put<TimeEntry>(
       `/workspaces/${wsId}/time_entries/${entry.id}`,
       buildUpdateBody(
         entry,
@@ -184,7 +184,11 @@ export async function entryEdit(args: string[]) {
         newTags !== null ? newTags : undefined
       )
     );
-    updated = await get<TimeEntry>(`/me/time_entries/${id}`);
+  }
+
+  if (!hasEntryChanges && !hasTagChanges) {
+    console.log('No changes.');
+    return;
   }
 
   const projectLabel = updated.project_name ? ` [${updated.project_name}]` : '';

--- a/tests/entry-edit-parseArgs.test.ts
+++ b/tests/entry-edit-parseArgs.test.ts
@@ -24,6 +24,16 @@ describe('entry-edit parseArgs', () => {
     expect(result.tags).toEqual(['dev', 'bug']);
   });
 
+  it('parses empty tags as a clear request', () => {
+    const result = parseArgs(['12345', '-t', '']);
+    expect(result.tags).toEqual([]);
+  });
+
+  it('trims tags and removes blanks and duplicates', () => {
+    const result = parseArgs(['12345', '-t', ' dev, ,bug,DEV ']);
+    expect(result.tags).toEqual(['dev', 'bug']);
+  });
+
   it('parses id with all flags', () => {
     const result = parseArgs(['12345', '-d', 'Updated', '-p', 'Project', '-t', 'review']);
     expect(result).toEqual({

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -71,10 +71,7 @@ describe('entryEdit command', () => {
   });
 
   it('replaces tags', async () => {
-    mockedGet.mockResolvedValueOnce({ ...baseEntry, tags: ['dev', 'sysadm'] }).mockResolvedValueOnce({
-      ...baseEntry,
-      tags: ['dev', 'dart'],
-    });
+    mockedGet.mockResolvedValue({ ...baseEntry, tags: ['dev', 'sysadm'] });
     mockedPut.mockResolvedValue({
       ...baseEntry,
       tags: ['dev', 'dart'],
@@ -89,22 +86,21 @@ describe('entryEdit command', () => {
       })
     );
     expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('tag_action');
-    expect(mockedGet).toHaveBeenLastCalledWith('/me/time_entries/100');
   });
 
   it('does not call update when requested tags already match', async () => {
     mockedGet.mockResolvedValue({ ...baseEntry, tags: ['dev', 'dart'] });
 
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     await entryEdit(['100', '-t', 'dev,dart']);
 
     expect(mockedPut).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith('No changes.');
+    logSpy.mockRestore();
   });
 
   it('clears tags', async () => {
-    mockedGet.mockResolvedValueOnce({ ...baseEntry, tags: ['dev'] }).mockResolvedValueOnce({
-      ...baseEntry,
-      tags: null,
-    });
+    mockedGet.mockResolvedValue({ ...baseEntry, tags: ['dev'] });
     mockedPut.mockResolvedValue({
       ...baseEntry,
       tags: null,

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -43,9 +43,10 @@ describe('entryEdit command', () => {
       expect.objectContaining({
         description: 'Updated',
         project_id: 10,
-        tags: ['dev'],
       })
     );
+    expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('tags');
+    expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('tag_action');
   });
 
   it('edits project by name', async () => {
@@ -69,21 +70,55 @@ describe('entryEdit command', () => {
     );
   });
 
-  it('edits tags', async () => {
-    mockedGet.mockResolvedValue({ ...baseEntry });
+  it('replaces tags', async () => {
+    mockedGet.mockResolvedValueOnce({ ...baseEntry, tags: ['dev', 'sysadm'] }).mockResolvedValueOnce({
+      ...baseEntry,
+      tags: ['dev', 'dart'],
+    });
     mockedPut.mockResolvedValue({
       ...baseEntry,
-      tags: ['review', 'bug'],
+      tags: ['dev', 'dart'],
     });
 
-    await entryEdit(['100', '-t', 'review,bug']);
+    await entryEdit(['100', '-t', 'dev,dart']);
 
     expect(mockedPut).toHaveBeenCalledWith(
       '/workspaces/123/time_entries/100',
       expect.objectContaining({
-        tags: ['review', 'bug'],
+        tags: ['dev', 'dart'],
       })
     );
+    expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('tag_action');
+    expect(mockedGet).toHaveBeenLastCalledWith('/me/time_entries/100');
+  });
+
+  it('does not call update when requested tags already match', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry, tags: ['dev', 'dart'] });
+
+    await entryEdit(['100', '-t', 'dev,dart']);
+
+    expect(mockedPut).not.toHaveBeenCalled();
+  });
+
+  it('clears tags', async () => {
+    mockedGet.mockResolvedValueOnce({ ...baseEntry, tags: ['dev'] }).mockResolvedValueOnce({
+      ...baseEntry,
+      tags: null,
+    });
+    mockedPut.mockResolvedValue({
+      ...baseEntry,
+      tags: null,
+    });
+
+    await entryEdit(['100', '-t', '']);
+
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        tags: [],
+      })
+    );
+    expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('tag_action');
   });
 
   it('prints not found when entry does not exist', async () => {
@@ -129,9 +164,9 @@ describe('entryEdit command', () => {
         start: '2025-06-15T10:00:00Z',
         description: 'Original',
         project_id: 10,
-        tags: ['dev'],
       })
     );
+    expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('tags');
   });
 
   it('edits duration combined with description', async () => {


### PR DESCRIPTION
## Summary

- Fix `entry-edit -t` to actually persist tag changes in Toggl Track
- Root cause: the old code used `...entry` spread which injected read-only fields (`id`, `project_name`, `at`, etc.) that caused the API to silently ignore the `tags` field
- Replace with clean `buildUpdateBody()` that sends only writable fields
- Add `normalizeTags()` for dedup/trim, `diffTags()` for no-op detection
- Update and expand tests for tag replacement, clearing, and no-op cases

Closes #122