### PR TITLE
feat: add workspace-list command (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ Run `tgp` without arguments to see all available commands.
 
 ### General
 
-| Command            | Description           | Docs                     |
-| ------------------ | --------------------- | ------------------------ |
-| `tgp auth <token>` | Save API token        |                          |
-| `tgp version`      | Show CLI version      |                          |
-| `tgp me`           | Verify authentication | [docs/me.md](docs/me.md) |
+| Command              | Description           | Docs                                             |
+| -------------------- | --------------------- | ------------------------------------------------ |
+| `tgp auth <token>`   | Save API token        |                                                  |
+| `tgp version`        | Show CLI version      |                                                  |
+| `tgp me`             | Verify authentication | [docs/me.md](docs/me.md)                         |
+| `tgp workspace-list` | List workspaces       | [docs/workspace-list.md](docs/workspace-list.md) |
 
 ### Entries
 

--- a/docs/workspace-list.md
+++ b/docs/workspace-list.md
@@ -1,0 +1,28 @@
+# `workspace-list` — List Workspaces
+
+Lists all Toggl Track workspaces available to the authenticated user.
+
+This command does not require `TOGGL_WORKSPACE_ID`. It is useful for finding the
+workspace ID to use in configuration.
+
+## Usage
+
+```bash
+tgp workspace-list
+```
+
+## Output
+
+```text
+ID           Name
+──────────── ────────────────────
+12345        My Workspace
+67890        Client Workspace
+```
+
+## Columns
+
+| Column | Description          |
+| ------ | -------------------- |
+| ID     | Toggl workspace ID   |
+| Name   | Toggl workspace name |

--- a/docs/workspace-list.md
+++ b/docs/workspace-list.md
@@ -14,10 +14,10 @@ tgp workspace-list
 ## Output
 
 ```text
-ID           Name
-──────────── ────────────────────
-12345        My Workspace
-67890        Client Workspace
+  ID           Name
+  ──────────── ────────────────────
+  12345        My Workspace
+  67890        Client Workspace
 ```
 
 ## Columns

--- a/src/commands/workspace-list.ts
+++ b/src/commands/workspace-list.ts
@@ -1,0 +1,23 @@
+import { get } from '../api.js';
+
+interface Workspace {
+  id: number;
+  name: string;
+  organization_id: number;
+}
+
+export async function workspaceList() {
+  const list = await get<Workspace[]>('/me/workspaces');
+
+  if (list.length === 0) {
+    console.log('No workspaces found');
+    return;
+  }
+
+  console.log(`${'ID'.padEnd(12)} Name`);
+  console.log(`${''.padEnd(12, '─')} ${''.padEnd(20, '─')}`);
+
+  for (const workspace of list) {
+    console.log(`${String(workspace.id).padEnd(12)} ${workspace.name}`);
+  }
+}

--- a/src/commands/workspace-list.ts
+++ b/src/commands/workspace-list.ts
@@ -3,7 +3,6 @@ import { get } from '../api.js';
 interface Workspace {
   id: number;
   name: string;
-  organization_id: number;
 }
 
 export async function workspaceList() {

--- a/src/commands/workspace-list.ts
+++ b/src/commands/workspace-list.ts
@@ -14,10 +14,10 @@ export async function workspaceList() {
     return;
   }
 
-  console.log(`${'ID'.padEnd(12)} Name`);
-  console.log(`${''.padEnd(12, '─')} ${''.padEnd(20, '─')}`);
+  console.log(`  ${'ID'.padEnd(12)} Name`);
+  console.log(`  ${''.padEnd(12, '─')} ${''.padEnd(20, '─')}`);
 
   for (const workspace of list) {
-    console.log(`${String(workspace.id).padEnd(12)} ${workspace.name}`);
+    console.log(`  ${String(workspace.id).padEnd(12)} ${workspace.name}`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { hasConfig, ConfigNotFoundError } from './config.js';
 import { entryList } from './commands/entry-list.js';
 import { week } from './commands/week.js';
 import { projectList } from './commands/project-list.js';
+import { workspaceList } from './commands/workspace-list.js';
 import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
@@ -55,6 +56,9 @@ if (command === 'auth') {
     case 'project-list':
       projectList();
       break;
+    case 'workspace-list':
+      workspaceList();
+      break;
     case 'entry-delete':
       entryDelete(args);
       break;
@@ -92,6 +96,7 @@ if (command === 'auth') {
       console.error('Usage: tgp <command>');
       console.error('Commands:');
       console.error('  auth           version         me');
+      console.error('  workspace-list');
       console.error('  track          stop            entry-edit      entry-list      entry-delete');
       console.error('  week');
       console.error('  project-list   project-create  project-rename  project-delete');

--- a/tests/workspace-list.test.ts
+++ b/tests/workspace-list.test.ts
@@ -16,8 +16,8 @@ describe('workspaceList command', () => {
 
   it('lists workspaces', async () => {
     mockedGet.mockResolvedValue([
-      { id: 12345, name: 'My Workspace', organization_id: 1 },
-      { id: 67890, name: 'Client Workspace', organization_id: 2 },
+      { id: 12345, name: 'My Workspace' },
+      { id: 67890, name: 'Client Workspace' },
     ]);
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/tests/workspace-list.test.ts
+++ b/tests/workspace-list.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
+}));
+
+import { get } from '../src/api.js';
+import { workspaceList } from '../src/commands/workspace-list.js';
+
+const mockedGet = vi.mocked(get);
+
+describe('workspaceList command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists workspaces', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 12345, name: 'My Workspace', organization_id: 1 },
+      { id: 67890, name: 'Client Workspace', organization_id: 2 },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await workspaceList();
+
+    expect(mockedGet).toHaveBeenCalledWith('/me/workspaces');
+    expect(logSpy).toHaveBeenCalledWith('ID           Name');
+    expect(logSpy).toHaveBeenCalledWith('──────────── ────────────────────');
+    expect(logSpy).toHaveBeenCalledWith('12345        My Workspace');
+    expect(logSpy).toHaveBeenCalledWith('67890        Client Workspace');
+    logSpy.mockRestore();
+  });
+
+  it('prints a message when no workspaces are found', async () => {
+    mockedGet.mockResolvedValue([]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await workspaceList();
+
+    expect(mockedGet).toHaveBeenCalledWith('/me/workspaces');
+    expect(logSpy).toHaveBeenCalledWith('No workspaces found');
+    logSpy.mockRestore();
+  });
+});

--- a/tests/workspace-list.test.ts
+++ b/tests/workspace-list.test.ts
@@ -24,10 +24,10 @@ describe('workspaceList command', () => {
     await workspaceList();
 
     expect(mockedGet).toHaveBeenCalledWith('/me/workspaces');
-    expect(logSpy).toHaveBeenCalledWith('ID           Name');
-    expect(logSpy).toHaveBeenCalledWith('──────────── ────────────────────');
-    expect(logSpy).toHaveBeenCalledWith('12345        My Workspace');
-    expect(logSpy).toHaveBeenCalledWith('67890        Client Workspace');
+    expect(logSpy).toHaveBeenCalledWith('  ID           Name');
+    expect(logSpy).toHaveBeenCalledWith('  ──────────── ────────────────────');
+    expect(logSpy).toHaveBeenCalledWith('  12345        My Workspace');
+    expect(logSpy).toHaveBeenCalledWith('  67890        Client Workspace');
     logSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

Adds `tgp workspace-list` to list Toggl Track workspaces available to the authenticated user.

## Changes

- Calls `GET /api/v9/me/workspaces` without requiring `TOGGL_WORKSPACE_ID`
- Prints workspace IDs and names in a small table
- Documents the command in README and `docs/workspace-list.md`
- Adds unit coverage for normal and empty responses

Closes #95.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run lint:md`
- `npm run format:check`
- Manual: `npm start -- workspace-list`