### PR TITLE
feat: add project archive and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ Coming soon — `client-list`, `client-add`, `client-rename`, `client-delete`.
 
 ### Projects
 
-| Command                          | Description             | Docs                                             |
-| -------------------------------- | ----------------------- | ------------------------------------------------ |
-| `tgp project-list`               | List workspace projects | [docs/project-list.md](docs/project-list.md)     |
-| `tgp project-create`             | Create a project        | [docs/project-create.md](docs/project-create.md) |
-| `tgp project-rename <id> <name>` | Rename a project        | [docs/project-rename.md](docs/project-rename.md) |
-| `tgp project-delete <id>`        | Delete a project        | [docs/project-delete.md](docs/project-delete.md) |
+| Command                          | Description             | Docs                                               |
+| -------------------------------- | ----------------------- | -------------------------------------------------- |
+| `tgp project-list`               | List workspace projects | [docs/project-list.md](docs/project-list.md)       |
+| `tgp project-create`             | Create a project        | [docs/project-create.md](docs/project-create.md)   |
+| `tgp project-rename <id> <name>` | Rename a project        | [docs/project-rename.md](docs/project-rename.md)   |
+| `tgp project-delete <id>`        | Delete a project        | [docs/project-delete.md](docs/project-delete.md)   |
+| `tgp project-archive <id>`       | Archive a project       | [docs/project-archive.md](docs/project-archive.md) |
+| `tgp project-restore <id>`       | Restore a project       | [docs/project-restore.md](docs/project-restore.md) |
 
 ### Tags
 

--- a/docs/project-archive.md
+++ b/docs/project-archive.md
@@ -1,0 +1,36 @@
+# `project-archive` — Archive a Project
+
+Archives an active project in your workspace. Find the project ID using `tgp project-list`.
+
+## Usage
+
+```bash
+tgp project-archive <project_id>
+```
+
+## Output
+
+```text
+Project 1234567890 archived.
+```
+
+## Arguments
+
+| Argument     | Description                 |
+| ------------ | --------------------------- |
+| `project_id` | Toggl project ID to archive |
+
+## Examples
+
+```bash
+tgp project-list
+#   1234567890   Backend
+#   9876543210   Frontend
+
+tgp project-archive 1234567890
+#   Project 1234567890 archived.
+```
+
+## Errors
+
+- `Project <id> not found.` — project does not exist in the workspace

--- a/docs/project-restore.md
+++ b/docs/project-restore.md
@@ -1,0 +1,36 @@
+# `project-restore` — Restore a Project
+
+Restores an archived project in your workspace. Find the project ID using `tgp project-list`.
+
+## Usage
+
+```bash
+tgp project-restore <project_id>
+```
+
+## Output
+
+```text
+Project 1234567890 restored.
+```
+
+## Arguments
+
+| Argument     | Description                 |
+| ------------ | --------------------------- |
+| `project_id` | Toggl project ID to restore |
+
+## Examples
+
+```bash
+tgp project-list
+#   1234567890   Backend
+#   9876543210   Frontend
+
+tgp project-restore 1234567890
+#   Project 1234567890 restored.
+```
+
+## Errors
+
+- `Project <id> not found.` — project does not exist in the workspace

--- a/src/commands/project-archive.ts
+++ b/src/commands/project-archive.ts
@@ -1,0 +1,36 @@
+import { config } from '../config.js';
+import { put } from '../api.js';
+
+interface Project {
+  id: number;
+}
+
+export async function projectArchive(args: string[]) {
+  const projectId = args[0];
+
+  if (!projectId) {
+    console.error('Usage: tgp project-archive <project_id>');
+    process.exit(1);
+  }
+
+  if (isNaN(Number(projectId))) {
+    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
+      active: false,
+    });
+    console.log(`Project ${updated.id} archived.`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Project ${projectId} not found.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/commands/project-restore.ts
+++ b/src/commands/project-restore.ts
@@ -1,0 +1,36 @@
+import { config } from '../config.js';
+import { put } from '../api.js';
+
+interface Project {
+  id: number;
+}
+
+export async function projectRestore(args: string[]) {
+  const projectId = args[0];
+
+  if (!projectId) {
+    console.error('Usage: tgp project-restore <project_id>');
+    process.exit(1);
+  }
+
+  if (isNaN(Number(projectId))) {
+    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+    process.exit(1);
+  }
+
+  const wsId = await config.getWorkspaceId();
+
+  try {
+    const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
+      active: true,
+    });
+    console.log(`Project ${updated.id} restored.`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Project ${projectId} not found.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,12 +103,12 @@ if (command === 'auth') {
     default:
       console.error('Usage: tgp <command>');
       console.error('Commands:');
-      console.error('  auth           version         me');
+      console.error('  auth             version          me');
       console.error('  workspace-list');
-      console.error('  track          stop            entry-edit      entry-list      entry-delete');
+      console.error('  track            stop             entry-edit       entry-list       entry-delete');
       console.error('  week');
-      console.error('  project-list   project-create  project-rename  project-delete');
-      console.error('  project-archive  project-restore');
-      console.error('  tag-list       tag-create      tag-rename      tag-delete');
+      console.error('  project-list     project-create   project-rename   project-archive  project-restore');
+      console.error('  project-delete');
+      console.error('  tag-list         tag-create       tag-rename       tag-delete');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { entryEdit } from './commands/entry-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { projectCreate } from './commands/project-create.js';
 import { projectDelete } from './commands/project-delete.js';
+import { projectArchive } from './commands/project-archive.js';
+import { projectRestore } from './commands/project-restore.js';
 import { auth } from './commands/auth.js';
 import { version } from './commands/version.js';
 
@@ -92,6 +94,12 @@ if (command === 'auth') {
     case 'project-delete':
       projectDelete(args);
       break;
+    case 'project-archive':
+      projectArchive(args);
+      break;
+    case 'project-restore':
+      projectRestore(args);
+      break;
     default:
       console.error('Usage: tgp <command>');
       console.error('Commands:');
@@ -100,6 +108,7 @@ if (command === 'auth') {
       console.error('  track          stop            entry-edit      entry-list      entry-delete');
       console.error('  week');
       console.error('  project-list   project-create  project-rename  project-delete');
+      console.error('  project-archive  project-restore');
       console.error('  tag-list       tag-create      tag-rename      tag-delete');
   }
 }

--- a/tests/project-archive.test.ts
+++ b/tests/project-archive.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  put: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { put } from '../src/api.js';
+import { projectArchive } from '../src/commands/project-archive.js';
+
+const mockedPut = vi.mocked(put);
+
+describe('projectArchive command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectArchive([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-archive <project_id>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits on non-numeric project ID', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectArchive(['abc'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('archives project and prints confirmation', async () => {
+    mockedPut.mockResolvedValue({ id: 456 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectArchive(['456']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      active: false,
+    });
+    expect(logSpy).toHaveBeenCalledWith('Project 456 archived.');
+    logSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await projectArchive(['999']);
+
+    expect(logSpy).toHaveBeenCalledWith('Project 999 not found.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(projectArchive(['123'])).rejects.toThrow('500');
+  });
+});

--- a/tests/project-restore.test.ts
+++ b/tests/project-restore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  put: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { put } from '../src/api.js';
+import { projectRestore } from '../src/commands/project-restore.js';
+
+const mockedPut = vi.mocked(put);
+
+describe('projectRestore command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRestore([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-restore <project_id>');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits on non-numeric project ID', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRestore(['abc'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('restores project and prints confirmation', async () => {
+    mockedPut.mockResolvedValue({ id: 456 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectRestore(['456']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      active: true,
+    });
+    expect(logSpy).toHaveBeenCalledWith('Project 456 restored.');
+    logSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await projectRestore(['999']);
+
+    expect(logSpy).toHaveBeenCalledWith('Project 999 not found.');
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(projectRestore(['123'])).rejects.toThrow('500');
+  });
+});


### PR DESCRIPTION
## Summary

Adds explicit project-archive and project-restore commands for Toggl projects.

## Changes

- Adds archive and restore command handlers using the existing Toggl project PUT pattern.
- Wires both commands into CLI dispatch and help output.
- Adds README/docs entries and focused Vitest coverage for validation, success, 404 handling, and non-404 error propagation.

## Validation

- npm test
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check
- npm run build
- pre-commit hook: format, source lint, markdown lint

Closes #92