### PR TITLE
feat: hide archived projects from project-list (#132)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ See README.md for available commands and usage.
   message. The default includes all commit titles as bullet points in the body, which
   is messy. Example:
   `gh pr merge <number> --squash --subject "feat: add project-rename (#21)" --body "" --delete-branch`
+- **Create PRs with `gh pr create` outside the sandbox**. Sandboxed `gh` may report
+  invalid auth or fail to reach GitHub even when the host keychain token is valid.
 
 This file describes common mistakes and confusion points that an agent may encounter as
 they work on this project. If you ever encounter something that surprises you or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ See README.md for available commands and usage.
   message. The default includes all commit titles as bullet points in the body, which
   is messy. Example:
   `gh pr merge <number> --squash --subject "feat: add project-rename (#21)" --body "" --delete-branch`
-- **Create PRs with `gh pr create` outside the sandbox**. Sandboxed `gh` may report
-  invalid auth or fail to reach GitHub even when the host keychain token is valid.
+- **Run `gh` commands outside the sandbox**. Sandboxed `gh` may report invalid auth
+  or fail to reach GitHub even when the host keychain token is valid.
 
 This file describes common mistakes and confusion points that an agent may encounter as
 they work on this project. If you ever encounter something that surprises you or

--- a/docs/project-list.md
+++ b/docs/project-list.md
@@ -1,14 +1,17 @@
 # `project-list` — List Projects
 
-Lists all projects in your workspace with IDs, names, clients, and status.
+Lists active projects in your workspace with IDs, names, clients, and status.
+Pass `--all` or `-a` to include archived projects.
 
 ## Usage
 
 ```bash
 tgp project-list
+tgp project-list --all
+tgp project-list -a
 ```
 
-## Output
+## Output with `--all`
 
 ```text
 Projects in workspace 21355416

--- a/docs/project-list.md
+++ b/docs/project-list.md
@@ -11,6 +11,17 @@ tgp project-list --all
 tgp project-list -a
 ```
 
+## Output
+
+```text
+Projects in workspace 21355416
+
+  ID           Name                            Client                Status
+  ──────────── ────────────────────────────── ──────────────────── ────────
+  1234567890   Dev-Pilot                       —                     active
+  1234567891   Client-X                        Acme Corp             active
+```
+
 ## Output with `--all`
 
 ```text

--- a/src/commands/project-list.ts
+++ b/src/commands/project-list.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
-import { DASH } from '../utils.js';
+import { DASH, parseOrExit } from '../utils.js';
 
 interface Project {
   id: number;
@@ -12,11 +12,26 @@ interface Project {
   status: string;
 }
 
-export async function projectList() {
-  const wsId = await config.getWorkspaceId();
-  const list = await get<Project[]>(`/workspaces/${wsId}/projects`);
+export function parseArgs(args: string[]): { includeArchived: boolean } {
+  if (args.length === 0) {
+    return { includeArchived: false };
+  }
 
-  if (list.length === 0) {
+  if (args.length === 1 && (args[0] === '--all' || args[0] === '-a')) {
+    return { includeArchived: true };
+  }
+
+  throw new Error('Usage: tgp project-list [--all|-a]');
+}
+
+export async function projectList(args: string[] = []) {
+  const { includeArchived } = parseOrExit(() => parseArgs(args));
+  const wsId = await config.getWorkspaceId();
+  const path = includeArchived ? `/workspaces/${wsId}/projects` : `/workspaces/${wsId}/projects?active=true`;
+  const list = await get<Project[]>(path);
+  const projects = includeArchived ? list : list.filter((p) => p.active);
+
+  if (projects.length === 0) {
     console.log('No projects found');
     return;
   }
@@ -25,7 +40,7 @@ export async function projectList() {
   console.log(`  ${'ID'.padEnd(12)} ${'Name'.padEnd(30)} ${'Client'.padEnd(20)} Status`);
   console.log(`  ${''.padEnd(12, '─')} ${''.padEnd(30, '─')} ${''.padEnd(20, '─')} ${''.padEnd(8, '─')}`);
 
-  for (const p of list) {
+  for (const p of projects) {
     const status = p.active ? 'active' : 'archived';
     const client = p.client_name ?? DASH;
     const line = `  ${String(p.id).padEnd(12)} ${p.name.slice(0, 30).padEnd(30)} ${client.slice(0, 20).padEnd(20)} ${status}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ if (command === 'auth') {
       week(args);
       break;
     case 'project-list':
-      projectList();
+      projectList(args);
       break;
     case 'workspace-list':
       workspaceList();

--- a/tests/project-list-parseArgs.test.ts
+++ b/tests/project-list-parseArgs.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseArgs } from '../src/commands/project-list.js';
+
+describe('project-list parseArgs', () => {
+  it('defaults to active projects only', () => {
+    expect(parseArgs([])).toEqual({ includeArchived: false });
+  });
+
+  it('accepts --all', () => {
+    expect(parseArgs(['--all'])).toEqual({ includeArchived: true });
+  });
+
+  it('accepts -a', () => {
+    expect(parseArgs(['-a'])).toEqual({ includeArchived: true });
+  });
+
+  it('throws usage on unknown flag', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow('Usage: tgp project-list [--all|-a]');
+  });
+});

--- a/tests/project-list.test.ts
+++ b/tests/project-list.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { get } from '../src/api.js';
+import { projectList } from '../src/commands/project-list.js';
+
+const mockedGet = vi.mocked(get);
+
+describe('projectList command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests active projects by default', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Active Project', active: true, client_name: null }]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectList([]);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects?active=true');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Active Project'));
+    logSpy.mockRestore();
+  });
+
+  it('filters archived projects from default output defensively', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Active Project', active: true, client_name: null },
+      { id: 789, name: 'Archived Project', active: false, client_name: null },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectList([]);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects?active=true');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Active Project'));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Archived Project'));
+    logSpy.mockRestore();
+  });
+
+  it('uses unfiltered endpoint with --all', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Active Project', active: true, client_name: null },
+      { id: 789, name: 'Archived Project', active: false, client_name: null },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectList(['--all']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Active Project'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Archived Project'));
+    logSpy.mockRestore();
+  });
+
+  it('uses unfiltered endpoint with -a', async () => {
+    mockedGet.mockResolvedValue([{ id: 789, name: 'Archived Project', active: false, client_name: null }]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectList(['-a']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Archived Project'));
+    logSpy.mockRestore();
+  });
+
+  it('prints a message when no projects are rendered', async () => {
+    mockedGet.mockResolvedValue([{ id: 789, name: 'Archived Project', active: false, client_name: null }]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectList([]);
+
+    expect(logSpy).toHaveBeenCalledWith('No projects found');
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Hide archived projects from `project-list` by default using Toggl's `active=true` projects query.
- Add `--all` / `-a` to preserve the previous unfiltered list behavior.
- Document the flag and add focused command and parser coverage.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- pre-commit hook: format, lint, markdown lint

Closes #132