### PR TITLE
feat: add project-edit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Coming soon — `client-list`, `client-add`, `client-rename`, `client-delete`.
 | -------------------------------- | ----------------------- | -------------------------------------------------- |
 | `tgp project-list`               | List workspace projects | [docs/project-list.md](docs/project-list.md)       |
 | `tgp project-create`             | Create a project        | [docs/project-create.md](docs/project-create.md)   |
+| `tgp project-edit <id>`          | Edit a project          | [docs/project-edit.md](docs/project-edit.md)       |
 | `tgp project-rename <id> <name>` | Rename a project        | [docs/project-rename.md](docs/project-rename.md)   |
 | `tgp project-delete <id>`        | Delete a project        | [docs/project-delete.md](docs/project-delete.md)   |
 | `tgp project-archive <id>`       | Archive a project       | [docs/project-archive.md](docs/project-archive.md) |

--- a/docs/project-edit.md
+++ b/docs/project-edit.md
@@ -1,0 +1,43 @@
+# `project-edit` — Edit a Project
+
+Edits an existing project in your workspace.
+
+## Usage
+
+```bash
+tgp project-edit <project_id> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]
+```
+
+At least one edit flag is required.
+
+## Output
+
+```text
+Project 1234567890 updated: name="Project Name" client="Acme Corp" color=#0b83d9 public
+```
+
+## Arguments
+
+| Argument     | Description              |
+| ------------ | ------------------------ |
+| `project_id` | Toggl project ID to edit |
+
+## Flags
+
+| Flag                          | Description                                       |
+| ----------------------------- | ------------------------------------------------- |
+| `-n`, `--name <name>`         | Rename the project                                |
+| `-c`, `--client <name or id>` | Assign a client by name or numeric ID             |
+| `--client ""`                 | Remove the project client                         |
+| `--color <hex>`               | Project color (e.g. `"#0b83d9"`)                  |
+| `--public`                    | Make the project visible to all workspace members |
+| `--private`                   | Make the project private                          |
+
+## Examples
+
+```bash
+tgp project-edit 1234567890 -n "Website Redesign"
+tgp project-edit 1234567890 -c "Acme Corp"
+tgp project-edit 1234567890 --client ""
+tgp project-edit 1234567890 --color "#ff0000" --public
+```

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,0 +1,26 @@
+import { get } from './api.js';
+
+interface Client {
+  id: number;
+  name: string;
+  wid: number;
+}
+
+export async function resolveClientId(wsId: number, clientInput: string): Promise<number> {
+  if (/^\d+$/.test(clientInput)) {
+    return Number(clientInput);
+  }
+
+  const clients = await get<Client[]>(`/workspaces/${wsId}/clients`);
+  const matches = clients.filter((c) => c.name.toLowerCase() === clientInput.toLowerCase());
+
+  if (matches.length === 0) {
+    throw new Error(`Client "${clientInput}" not found.`);
+  }
+  if (matches.length > 1) {
+    const list = matches.map((c) => `  ${c.id}  ${c.name}`).join('\n');
+    throw new Error(`Multiple clients match "${clientInput}":\n${list}`);
+  }
+
+  return matches[0].id;
+}

--- a/src/commands/project-create.ts
+++ b/src/commands/project-create.ts
@@ -1,5 +1,6 @@
 import { config } from '../config.js';
-import { get, post } from '../api.js';
+import { post } from '../api.js';
+import { resolveClientId } from '../clients.js';
 import { parseOrExit } from '../utils.js';
 
 interface Project {
@@ -7,12 +8,6 @@ interface Project {
   name: string;
   client_id: number | null;
   client_name: string | null;
-}
-
-interface Client {
-  id: number;
-  name: string;
-  wid: number;
 }
 
 const VALID_FLAGS = new Set(['-c', '--client', '--color', '--public']);
@@ -48,25 +43,6 @@ function parseArgs(args: string[]) {
   }
 
   return { name, client, color, isPublic };
-}
-
-async function resolveClientId(wsId: number, clientInput: string): Promise<number> {
-  if (/^\d+$/.test(clientInput)) {
-    return Number(clientInput);
-  }
-
-  const clients = await get<Client[]>(`/workspaces/${wsId}/clients`);
-  const matches = clients.filter((c) => c.name.toLowerCase() === clientInput.toLowerCase());
-
-  if (matches.length === 0) {
-    throw new Error(`Client "${clientInput}" not found.`);
-  }
-  if (matches.length > 1) {
-    const list = matches.map((c) => `  ${c.id}  ${c.name}`).join('\n');
-    throw new Error(`Multiple clients match "${clientInput}":\n${list}`);
-  }
-
-  return matches[0].id;
 }
 
 export async function projectCreate(args: string[]) {

--- a/src/commands/project-edit.ts
+++ b/src/commands/project-edit.ts
@@ -17,7 +17,7 @@ interface ParsedArgs {
   name: string | null;
   client: string | null;
   color: string | null;
-  visibility: boolean | null;
+  isPrivate: boolean | null;
 }
 
 const USAGE =
@@ -36,7 +36,7 @@ export function parseArgs(args: string[]): ParsedArgs {
   let name: string | null = null;
   let client: string | null = null;
   let color: string | null = null;
-  let visibility: boolean | null = null;
+  let isPrivate: boolean | null = null;
 
   if (!projectId) {
     throw new Error(USAGE);
@@ -63,29 +63,29 @@ export function parseArgs(args: string[]): ParsedArgs {
       color = requireValue(args, i, '--color');
       i++;
     } else if (args[i] === '--public') {
-      if (visibility === true) {
+      if (isPrivate === true) {
         throw new Error('Cannot use both --public and --private.');
       }
-      visibility = false;
+      isPrivate = false;
     } else if (args[i] === '--private') {
-      if (visibility === false) {
+      if (isPrivate === false) {
         throw new Error('Cannot use both --public and --private.');
       }
-      visibility = true;
+      isPrivate = true;
     } else {
       throw new Error(`Unexpected argument: ${args[i]}.`);
     }
   }
 
-  if (name === null && client === null && color === null && visibility === null) {
+  if (name === null && client === null && color === null && isPrivate === null) {
     throw new Error('Nothing to edit. Provide at least one of: -n, -c, --color, --public, --private');
   }
 
-  return { projectId, name, client, color, visibility };
+  return { projectId, name, client, color, isPrivate };
 }
 
 export async function projectEdit(args: string[]) {
-  const { projectId, name, client, color, visibility } = parseOrExit(() => parseArgs(args));
+  const { projectId, name, client, color, isPrivate } = parseOrExit(() => parseArgs(args));
   const wsId = await config.getWorkspaceId();
   const body: Record<string, unknown> = {};
 
@@ -106,8 +106,8 @@ export async function projectEdit(args: string[]) {
     body.color = color;
   }
 
-  if (visibility !== null) {
-    body.is_private = visibility;
+  if (isPrivate !== null) {
+    body.is_private = isPrivate;
   }
 
   try {

--- a/src/commands/project-edit.ts
+++ b/src/commands/project-edit.ts
@@ -1,0 +1,128 @@
+import { config } from '../config.js';
+import { put } from '../api.js';
+import { resolveClientId } from '../clients.js';
+import { parseOrExit } from '../utils.js';
+
+interface Project {
+  id: number;
+  name: string;
+  client_id: number | null;
+  client_name: string | null;
+  color: string;
+  is_private: boolean;
+}
+
+interface ParsedArgs {
+  projectId: string;
+  name: string | null;
+  client: string | null;
+  color: string | null;
+  visibility: boolean | null;
+}
+
+const USAGE =
+  'Usage: tgp project-edit <project_id> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]';
+const VALID_FLAGS = new Set(['-n', '--name', '-c', '--client', '--color', '--public', '--private']);
+
+function requireValue(args: string[], index: number, flagName: string): string {
+  if (index + 1 >= args.length) {
+    throw new Error(`${flagName} requires a value.`);
+  }
+  return args[index + 1];
+}
+
+export function parseArgs(args: string[]): ParsedArgs {
+  const projectId = args[0];
+  let name: string | null = null;
+  let client: string | null = null;
+  let color: string | null = null;
+  let visibility: boolean | null = null;
+
+  if (!projectId) {
+    throw new Error(USAGE);
+  }
+
+  if (isNaN(Number(projectId))) {
+    throw new Error(`Invalid project ID: "${projectId}". Must be a number.`);
+  }
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i].startsWith('-') && !VALID_FLAGS.has(args[i])) {
+      throw new Error(
+        `Unknown flag: ${args[i]}. Valid flags: -n/--name, -c/--client, --color, --public, --private`
+      );
+    }
+
+    if (args[i] === '-n' || args[i] === '--name') {
+      name = requireValue(args, i, '--name');
+      i++;
+    } else if (args[i] === '-c' || args[i] === '--client') {
+      client = requireValue(args, i, '--client');
+      i++;
+    } else if (args[i] === '--color') {
+      color = requireValue(args, i, '--color');
+      i++;
+    } else if (args[i] === '--public') {
+      if (visibility === true) {
+        throw new Error('Cannot use both --public and --private.');
+      }
+      visibility = false;
+    } else if (args[i] === '--private') {
+      if (visibility === false) {
+        throw new Error('Cannot use both --public and --private.');
+      }
+      visibility = true;
+    } else {
+      throw new Error(`Unexpected argument: ${args[i]}.`);
+    }
+  }
+
+  if (name === null && client === null && color === null && visibility === null) {
+    throw new Error('Nothing to edit. Provide at least one of: -n, -c, --color, --public, --private');
+  }
+
+  return { projectId, name, client, color, visibility };
+}
+
+export async function projectEdit(args: string[]) {
+  const { projectId, name, client, color, visibility } = parseOrExit(() => parseArgs(args));
+  const wsId = await config.getWorkspaceId();
+  const body: Record<string, unknown> = {};
+
+  if (name !== null) {
+    body.name = name;
+  }
+
+  if (client !== null) {
+    try {
+      body.client_id = client === '' ? null : await resolveClientId(wsId, client);
+    } catch (e) {
+      console.error((e as Error).message);
+      process.exit(1);
+    }
+  }
+
+  if (color !== null) {
+    body.color = color;
+  }
+
+  if (visibility !== null) {
+    body.is_private = visibility;
+  }
+
+  try {
+    const project = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, body);
+    const clientLabel = project.client_name ?? 'None';
+    const visibilityLabel = project.is_private ? 'private' : 'public';
+    console.log(
+      `Project ${project.id} updated: name="${project.name}" client="${clientLabel}" color=${project.color} ${visibilityLabel}`
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('404')) {
+      console.error(`Project ${projectId} not found.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { tagCreate } from './commands/tag-create.js';
 import { tagRename } from './commands/tag-rename.js';
 import { tagDelete } from './commands/tag-delete.js';
 import { entryEdit } from './commands/entry-edit.js';
+import { projectEdit } from './commands/project-edit.js';
 import { projectRename } from './commands/project-rename.js';
 import { projectCreate } from './commands/project-create.js';
 import { projectDelete } from './commands/project-delete.js';
@@ -88,6 +89,9 @@ if (command === 'auth') {
     case 'project-create':
       projectCreate(args);
       break;
+    case 'project-edit':
+      projectEdit(args);
+      break;
     case 'project-rename':
       projectRename(args);
       break;
@@ -107,8 +111,8 @@ if (command === 'auth') {
       console.error('  workspace-list');
       console.error('  track            stop             entry-edit       entry-list       entry-delete');
       console.error('  week');
-      console.error('  project-list     project-create   project-rename   project-archive  project-restore');
-      console.error('  project-delete');
+      console.error('  project-list     project-create   project-edit     project-rename   project-archive');
+      console.error('  project-restore  project-delete');
       console.error('  tag-list         tag-create       tag-rename       tag-delete');
   }
 }

--- a/tests/project-edit.test.ts
+++ b/tests/project-edit.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
+  put: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { get, put } from '../src/api.js';
+import { projectEdit } from '../src/commands/project-edit.js';
+
+const mockedGet = vi.mocked(get);
+const mockedPut = vi.mocked(put);
+
+const updatedProject = {
+  id: 456,
+  name: 'New Project',
+  client_id: 50,
+  client_name: 'Acme Corp',
+  color: '#0b83d9',
+  is_private: false,
+};
+
+describe('projectEdit command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no ID provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit([])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Usage: tgp project-edit <project_id> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits with error when project ID is not numeric', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['abc', '-n', 'New Project'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits on unknown flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '--unknown'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unknown flag: --unknown. Valid flags: -n/--name, -c/--client, --color, --public, --private'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when flag value is missing', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '--color'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('--color requires a value.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when no edit flags are provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Nothing to edit. Provide at least one of: -n, -c, --color, --public, --private'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits on unexpected positional argument', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', 'stray', '-n', 'New Project'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Unexpected argument: stray.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('updates name only and does not send visibility when omitted', async () => {
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '-n', 'New Project']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      name: 'New Project',
+    });
+    expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('is_private');
+    logSpy.mockRestore();
+  });
+
+  it('updates color only', async () => {
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '--color', '#0b83d9']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      color: '#0b83d9',
+    });
+    logSpy.mockRestore();
+  });
+
+  it('updates project to public', async () => {
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '--public']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      is_private: false,
+    });
+    logSpy.mockRestore();
+  });
+
+  it('updates project to private', async () => {
+    mockedPut.mockResolvedValue({ ...updatedProject, is_private: true });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '--private']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      is_private: true,
+    });
+    logSpy.mockRestore();
+  });
+
+  it('rejects both visibility flags', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '--public', '--private'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Cannot use both --public and --private.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('updates client with numeric ID directly', async () => {
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '-c', '50']);
+
+    expect(mockedGet).not.toHaveBeenCalled();
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      client_id: 50,
+    });
+    logSpy.mockRestore();
+  });
+
+  it('updates client by name', async () => {
+    mockedGet.mockResolvedValue([{ id: 50, name: 'Acme Corp', wid: 123 }]);
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '-c', 'Acme Corp']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/clients');
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      client_id: 50,
+    });
+    logSpy.mockRestore();
+  });
+
+  it('unsets client with empty client value', async () => {
+    mockedPut.mockResolvedValue({ ...updatedProject, client_id: null, client_name: null });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '--client', '']);
+
+    expect(mockedGet).not.toHaveBeenCalled();
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      client_id: null,
+    });
+    logSpy.mockRestore();
+  });
+
+  it('exits when client name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 50, name: 'Other Corp', wid: 123 }]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '-c', 'Missing'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Client "Missing" not found.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits on ambiguous client name match', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 50, name: 'Acme Corp', wid: 123 },
+      { id: 51, name: 'acme corp', wid: 123 },
+    ]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '-c', 'Acme Corp'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multiple clients match "Acme Corp":\n  50  Acme Corp\n  51  acme corp'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('handles 404 error gracefully', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 404: Not Found'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await projectEdit(['999', '-n', 'New Project']);
+
+    expect(errorSpy).toHaveBeenCalledWith('Project 999 not found.');
+    errorSpy.mockRestore();
+  });
+
+  it('re-throws non-404 errors', async () => {
+    mockedPut.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(projectEdit(['456', '-n', 'New Project'])).rejects.toThrow('500');
+  });
+
+  it('prints confirmation from updated project response', async () => {
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '-n', 'New Project']);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'Project 456 updated: name="New Project" client="Acme Corp" color=#0b83d9 public'
+    );
+    logSpy.mockRestore();
+  });
+
+  it('prints None for missing client in confirmation', async () => {
+    mockedPut.mockResolvedValue({ ...updatedProject, client_id: null, client_name: null, is_private: true });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '--client', '']);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'Project 456 updated: name="New Project" client="None" color=#0b83d9 private'
+    );
+    logSpy.mockRestore();
+  });
+});

--- a/tests/project-edit.test.ts
+++ b/tests/project-edit.test.ts
@@ -170,6 +170,20 @@ describe('projectEdit command', () => {
     logSpy.mockRestore();
   });
 
+  it('updates multiple project fields together', async () => {
+    mockedPut.mockResolvedValue({ ...updatedProject, name: 'Combined', color: '#ff0000' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['456', '-n', 'Combined', '--color', '#ff0000', '--public']);
+
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      name: 'Combined',
+      color: '#ff0000',
+      is_private: false,
+    });
+    logSpy.mockRestore();
+  });
+
   it('rejects both visibility flags', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');


### PR DESCRIPTION
## Summary

Adds `tgp project-edit` for editing project name, client, color, and visibility from issue #91.

## Changes

- Add the `project-edit` command with partial PUT updates and validation for missing flags, bad IDs, unknown flags, stray positional args, and conflicting visibility flags.
- Extract shared client name/ID resolution into `src/clients.ts` and reuse it from `project-create`.
- Document the new command and add README command table coverage.
- Add unit tests for edit body shape, client resolution/unset behavior, visibility tristate behavior, success output, and API error handling.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- pre-commit hook: format, lint, markdown lint
