### PR TITLE
feat: allow project commands to use names (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ Coming soon — `client-list`, `client-add`, `client-rename`, `client-delete`.
 
 ### Projects
 
-| Command                          | Description             | Docs                                               |
-| -------------------------------- | ----------------------- | -------------------------------------------------- |
-| `tgp project-list`               | List workspace projects | [docs/project-list.md](docs/project-list.md)       |
-| `tgp project-create`             | Create a project        | [docs/project-create.md](docs/project-create.md)   |
-| `tgp project-edit <id>`          | Edit a project          | [docs/project-edit.md](docs/project-edit.md)       |
-| `tgp project-rename <id> <name>` | Rename a project        | [docs/project-rename.md](docs/project-rename.md)   |
-| `tgp project-delete <id>`        | Delete a project        | [docs/project-delete.md](docs/project-delete.md)   |
-| `tgp project-archive <id>`       | Archive a project       | [docs/project-archive.md](docs/project-archive.md) |
-| `tgp project-restore <id>`       | Restore a project       | [docs/project-restore.md](docs/project-restore.md) |
+| Command                               | Description             | Docs                                               |
+| ------------------------------------- | ----------------------- | -------------------------------------------------- |
+| `tgp project-list`                    | List workspace projects | [docs/project-list.md](docs/project-list.md)       |
+| `tgp project-create`                  | Create a project        | [docs/project-create.md](docs/project-create.md)   |
+| `tgp project-edit <project>`          | Edit a project          | [docs/project-edit.md](docs/project-edit.md)       |
+| `tgp project-rename <project> <name>` | Rename a project        | [docs/project-rename.md](docs/project-rename.md)   |
+| `tgp project-delete <project>`        | Delete a project        | [docs/project-delete.md](docs/project-delete.md)   |
+| `tgp project-archive <project>`       | Archive a project       | [docs/project-archive.md](docs/project-archive.md) |
+| `tgp project-restore <project>`       | Restore a project       | [docs/project-restore.md](docs/project-restore.md) |
 
 ### Tags
 

--- a/docs/project-archive.md
+++ b/docs/project-archive.md
@@ -1,12 +1,16 @@
 # `project-archive` — Archive a Project
 
-Archives an active project in your workspace. Find the project ID using `tgp project-list`.
+Archives an active project in your workspace.
 
 ## Usage
 
 ```bash
-tgp project-archive <project_id>
+tgp project-archive <project>
 ```
+
+`<project>` can be a numeric project ID or an exact project name. Quotes are
+only needed when your shell requires them, such as names containing spaces or
+special characters.
 
 ## Output
 
@@ -16,9 +20,9 @@ Project 1234567890 archived.
 
 ## Arguments
 
-| Argument     | Description                 |
-| ------------ | --------------------------- |
-| `project_id` | Toggl project ID to archive |
+| Argument  | Description                                 |
+| --------- | ------------------------------------------- |
+| `project` | Project ID or exact project name to archive |
 
 ## Examples
 
@@ -29,8 +33,17 @@ tgp project-list
 
 tgp project-archive 1234567890
 #   Project 1234567890 archived.
+
+tgp project-archive Frontend
+#   Project 9876543210 archived.
 ```
 
 ## Errors
 
-- `Project <id> not found.` — project does not exist in the workspace
+- `Project <id> not found.` — project ID does not exist in the workspace
+- `Project "<name>" not found.` — no project has that exact name
+- `Multiple projects match "<name>". Use the numeric project ID:` — more than
+  one project matches case-insensitively, including names that differ only by
+  case
+- Numeric-looking project names are interpreted as IDs and cannot be targeted by
+  name

--- a/docs/project-delete.md
+++ b/docs/project-delete.md
@@ -1,12 +1,16 @@
 # `project-delete` — Delete a Project
 
-Deletes a project from your workspace. Find the project ID using `tgp project-list`.
+Deletes a project from your workspace.
 
 ## Usage
 
 ```bash
-tgp project-delete <project_id>
+tgp project-delete <project>
 ```
+
+`<project>` can be a numeric project ID or an exact project name. Quotes are
+only needed when your shell requires them, such as names containing spaces or
+special characters.
 
 ## Output
 
@@ -16,9 +20,9 @@ Project 1234567890 deleted.
 
 ## Arguments
 
-| Argument     | Description                |
-| ------------ | -------------------------- |
-| `project_id` | Toggl project ID to delete |
+| Argument  | Description                                |
+| --------- | ------------------------------------------ |
+| `project` | Project ID or exact project name to delete |
 
 ## Examples
 
@@ -29,8 +33,17 @@ tgp project-list
 
 tgp project-delete 1234567890
 #   Project 1234567890 deleted.
+
+tgp project-delete Frontend
+#   Project 9876543210 deleted.
 ```
 
 ## Errors
 
-- `Project <id> not found.` — project does not exist in the workspace
+- `Project <id> not found.` — project ID does not exist in the workspace
+- `Project "<name>" not found.` — no project has that exact name
+- `Multiple projects match "<name>". Use the numeric project ID:` — more than
+  one project matches case-insensitively, including names that differ only by
+  case
+- Numeric-looking project names are interpreted as IDs and cannot be targeted by
+  name

--- a/docs/project-edit.md
+++ b/docs/project-edit.md
@@ -5,10 +5,13 @@ Edits an existing project in your workspace.
 ## Usage
 
 ```bash
-tgp project-edit <project_id> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]
+tgp project-edit <project> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]
 ```
 
 At least one edit flag is required.
+`<project>` can be a numeric project ID or an exact project name. Quotes are
+only needed when your shell requires them, such as names containing spaces or
+special characters.
 
 ## Output
 
@@ -18,9 +21,9 @@ Project 1234567890 updated: name="Project Name" client="Acme Corp" color=#0b83d9
 
 ## Arguments
 
-| Argument     | Description              |
-| ------------ | ------------------------ |
-| `project_id` | Toggl project ID to edit |
+| Argument  | Description                              |
+| --------- | ---------------------------------------- |
+| `project` | Project ID or exact project name to edit |
 
 ## Flags
 
@@ -37,7 +40,16 @@ Project 1234567890 updated: name="Project Name" client="Acme Corp" color=#0b83d9
 
 ```bash
 tgp project-edit 1234567890 -n "Website Redesign"
-tgp project-edit 1234567890 -c "Acme Corp"
+tgp project-edit Backend -c "Acme Corp"
 tgp project-edit 1234567890 --client ""
-tgp project-edit 1234567890 --color "#ff0000" --public
+tgp project-edit "Old Project" --color "#ff0000" --public
 ```
+
+## Errors
+
+- `Project "<name>" not found.` — no project has that exact name
+- `Multiple projects match "<name>". Use the numeric project ID:` — more than
+  one project matches case-insensitively, including names that differ only by
+  case
+- Numeric-looking project names are interpreted as IDs and cannot be targeted by
+  name

--- a/docs/project-rename.md
+++ b/docs/project-rename.md
@@ -5,8 +5,12 @@ Renames an existing project in your workspace.
 ## Usage
 
 ```bash
-tgp project-rename <project_id> "New Name"
+tgp project-rename <project> "New Name"
 ```
+
+`<project>` can be a numeric project ID or an exact project name. Quotes are
+only needed when your shell requires them, such as names containing spaces or
+special characters.
 
 ## Output
 
@@ -16,13 +20,23 @@ Project 1234567890 renamed to "New Name"
 
 ## Arguments
 
-| Argument     | Description                |
-| ------------ | -------------------------- |
-| `project_id` | Toggl project ID to rename |
-| `"New Name"` | New name for the project   |
+| Argument     | Description                                |
+| ------------ | ------------------------------------------ |
+| `project`    | Project ID or exact project name to rename |
+| `"New Name"` | New name for the project                   |
 
 ## Examples
 
 ```bash
 tgp project-rename 1234567890 "Website Redesign"
+tgp project-rename Backend "API Backend"
 ```
+
+## Errors
+
+- `Project "<name>" not found.` — no project has that exact name
+- `Multiple projects match "<name>". Use the numeric project ID:` — more than
+  one project matches case-insensitively, including names that differ only by
+  case
+- Numeric-looking project names are interpreted as IDs and cannot be targeted by
+  name

--- a/docs/project-restore.md
+++ b/docs/project-restore.md
@@ -1,12 +1,16 @@
 # `project-restore` — Restore a Project
 
-Restores an archived project in your workspace. Find the project ID using `tgp project-list`.
+Restores an archived project in your workspace.
 
 ## Usage
 
 ```bash
-tgp project-restore <project_id>
+tgp project-restore <project>
 ```
+
+`<project>` can be a numeric project ID or an exact project name. Quotes are
+only needed when your shell requires them, such as names containing spaces or
+special characters.
 
 ## Output
 
@@ -16,21 +20,30 @@ Project 1234567890 restored.
 
 ## Arguments
 
-| Argument     | Description                 |
-| ------------ | --------------------------- |
-| `project_id` | Toggl project ID to restore |
+| Argument  | Description                                 |
+| --------- | ------------------------------------------- |
+| `project` | Project ID or exact project name to restore |
 
 ## Examples
 
 ```bash
-tgp project-list
+tgp project-list --all
 #   1234567890   Backend
-#   9876543210   Frontend
+#   9876543210   Old Project
 
 tgp project-restore 1234567890
 #   Project 1234567890 restored.
+
+tgp project-restore "Old Project"
+#   Project 9876543210 restored.
 ```
 
 ## Errors
 
-- `Project <id> not found.` — project does not exist in the workspace
+- `Project <id> not found.` — project ID does not exist in the workspace
+- `Project "<name>" not found.` — no project has that exact name
+- `Multiple projects match "<name>". Use the numeric project ID:` — more than
+  one project matches case-insensitively, including names that differ only by
+  case
+- Numeric-looking project names are interpreted as IDs and cannot be targeted by
+  name

--- a/src/commands/project-archive.ts
+++ b/src/commands/project-archive.ts
@@ -1,24 +1,28 @@
 import { config } from '../config.js';
 import { put } from '../api.js';
+import { resolveProjectId } from '../projects.js';
 
 interface Project {
   id: number;
 }
 
 export async function projectArchive(args: string[]) {
-  const projectId = args[0];
+  const projectInput = args[0];
 
-  if (!projectId) {
-    console.error('Usage: tgp project-archive <project_id>');
-    process.exit(1);
-  }
-
-  if (isNaN(Number(projectId))) {
-    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+  if (!projectInput) {
+    console.error('Usage: tgp project-archive <project>');
     process.exit(1);
   }
 
   const wsId = await config.getWorkspaceId();
+  let projectId: number;
+
+  try {
+    projectId = await resolveProjectId(wsId, projectInput);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
 
   try {
     const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
@@ -28,7 +32,7 @@ export async function projectArchive(args: string[]) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes('404')) {
-      console.error(`Project ${projectId} not found.`);
+      console.error(`Project ${projectInput} not found.`);
       return;
     }
     throw e;

--- a/src/commands/project-delete.ts
+++ b/src/commands/project-delete.ts
@@ -1,20 +1,24 @@
 import { config } from '../config.js';
 import { del } from '../api.js';
+import { resolveProjectId } from '../projects.js';
 
 export async function projectDelete(args: string[]) {
-  const projectId = args[0];
+  const projectInput = args[0];
 
-  if (!projectId) {
-    console.error('Usage: tgp project-delete <project_id>');
-    process.exit(1);
-  }
-
-  if (isNaN(Number(projectId))) {
-    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+  if (!projectInput) {
+    console.error('Usage: tgp project-delete <project>');
     process.exit(1);
   }
 
   const wsId = await config.getWorkspaceId();
+  let projectId: number;
+
+  try {
+    projectId = await resolveProjectId(wsId, projectInput);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
 
   try {
     await del(`/workspaces/${wsId}/projects/${projectId}`);
@@ -22,7 +26,7 @@ export async function projectDelete(args: string[]) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes('404')) {
-      console.error(`Project ${projectId} not found.`);
+      console.error(`Project ${projectInput} not found.`);
       return;
     }
     throw e;

--- a/src/commands/project-edit.ts
+++ b/src/commands/project-edit.ts
@@ -1,6 +1,7 @@
 import { config } from '../config.js';
 import { put } from '../api.js';
 import { resolveClientId } from '../clients.js';
+import { resolveProjectId } from '../projects.js';
 import { parseOrExit } from '../utils.js';
 
 interface Project {
@@ -13,7 +14,7 @@ interface Project {
 }
 
 interface ParsedArgs {
-  projectId: string;
+  project: string;
   name: string | null;
   client: string | null;
   color: string | null;
@@ -21,7 +22,7 @@ interface ParsedArgs {
 }
 
 const USAGE =
-  'Usage: tgp project-edit <project_id> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]';
+  'Usage: tgp project-edit <project> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]';
 const VALID_FLAGS = new Set(['-n', '--name', '-c', '--client', '--color', '--public', '--private']);
 
 function requireValue(args: string[], index: number, flagName: string): string {
@@ -32,18 +33,14 @@ function requireValue(args: string[], index: number, flagName: string): string {
 }
 
 export function parseArgs(args: string[]): ParsedArgs {
-  const projectId = args[0];
+  const project = args[0];
   let name: string | null = null;
   let client: string | null = null;
   let color: string | null = null;
   let isPrivate: boolean | null = null;
 
-  if (!projectId) {
+  if (!project) {
     throw new Error(USAGE);
-  }
-
-  if (isNaN(Number(projectId))) {
-    throw new Error(`Invalid project ID: "${projectId}". Must be a number.`);
   }
 
   for (let i = 1; i < args.length; i++) {
@@ -81,13 +78,21 @@ export function parseArgs(args: string[]): ParsedArgs {
     throw new Error('Nothing to edit. Provide at least one of: -n, -c, --color, --public, --private');
   }
 
-  return { projectId, name, client, color, isPrivate };
+  return { project, name, client, color, isPrivate };
 }
 
 export async function projectEdit(args: string[]) {
-  const { projectId, name, client, color, isPrivate } = parseOrExit(() => parseArgs(args));
+  const { project: projectInput, name, client, color, isPrivate } = parseOrExit(() => parseArgs(args));
   const wsId = await config.getWorkspaceId();
   const body: Record<string, unknown> = {};
+  let projectId: number;
+
+  try {
+    projectId = await resolveProjectId(wsId, projectInput);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
 
   if (name !== null) {
     body.name = name;
@@ -120,7 +125,7 @@ export async function projectEdit(args: string[]) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes('404')) {
-      console.error(`Project ${projectId} not found.`);
+      console.error(`Project ${projectInput} not found.`);
       return;
     }
     throw e;

--- a/src/commands/project-rename.ts
+++ b/src/commands/project-rename.ts
@@ -1,5 +1,6 @@
 import { config } from '../config.js';
 import { put } from '../api.js';
+import { resolveProjectId } from '../projects.js';
 
 interface Project {
   id: number;
@@ -7,20 +8,23 @@ interface Project {
 }
 
 export async function projectRename(args: string[]) {
-  const projectId = args[0];
+  const projectInput = args[0];
   const newName = args[1];
 
-  if (!projectId || !newName) {
-    console.error('Usage: tgp project-rename <project_id> "New Name"');
-    process.exit(1);
-  }
-
-  if (isNaN(Number(projectId))) {
-    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+  if (!projectInput || !newName) {
+    console.error('Usage: tgp project-rename <project> "New Name"');
     process.exit(1);
   }
 
   const wsId = await config.getWorkspaceId();
+  let projectId: number;
+
+  try {
+    projectId = await resolveProjectId(wsId, projectInput);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
 
   try {
     const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
@@ -30,7 +34,7 @@ export async function projectRename(args: string[]) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes('404')) {
-      console.error(`Project ${projectId} not found.`);
+      console.error(`Project ${projectInput} not found.`);
       return;
     }
     throw e;

--- a/src/commands/project-restore.ts
+++ b/src/commands/project-restore.ts
@@ -1,24 +1,28 @@
 import { config } from '../config.js';
 import { put } from '../api.js';
+import { resolveProjectId } from '../projects.js';
 
 interface Project {
   id: number;
 }
 
 export async function projectRestore(args: string[]) {
-  const projectId = args[0];
+  const projectInput = args[0];
 
-  if (!projectId) {
-    console.error('Usage: tgp project-restore <project_id>');
-    process.exit(1);
-  }
-
-  if (isNaN(Number(projectId))) {
-    console.error(`Invalid project ID: "${projectId}". Must be a number.`);
+  if (!projectInput) {
+    console.error('Usage: tgp project-restore <project>');
     process.exit(1);
   }
 
   const wsId = await config.getWorkspaceId();
+  let projectId: number;
+
+  try {
+    projectId = await resolveProjectId(wsId, projectInput);
+  } catch (e) {
+    console.error((e as Error).message);
+    process.exit(1);
+  }
 
   try {
     const updated = await put<Project>(`/workspaces/${wsId}/projects/${projectId}`, {
@@ -28,7 +32,7 @@ export async function projectRestore(args: string[]) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes('404')) {
-      console.error(`Project ${projectId} not found.`);
+      console.error(`Project ${projectInput} not found.`);
       return;
     }
     throw e;

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,25 @@
+import { get } from './api.js';
+
+interface Project {
+  id: number;
+  name: string;
+}
+
+export async function resolveProjectId(wsId: number, projectInput: string): Promise<number> {
+  if (/^\d+$/.test(projectInput)) {
+    return Number(projectInput);
+  }
+
+  const projects = await get<Project[]>(`/workspaces/${wsId}/projects`);
+  const matches = projects.filter((p) => p.name.toLowerCase() === projectInput.toLowerCase());
+
+  if (matches.length === 0) {
+    throw new Error(`Project "${projectInput}" not found.`);
+  }
+  if (matches.length > 1) {
+    const list = matches.map((p) => `  ${p.id}  ${p.name}`).join('\n');
+    throw new Error(`Multiple projects match "${projectInput}". Use the numeric project ID:\n${list}`);
+  }
+
+  return matches[0].id;
+}

--- a/tests/project-archive.test.ts
+++ b/tests/project-archive.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
   put: vi.fn(),
 }));
 
@@ -10,9 +11,10 @@ vi.mock('../src/config.js', () => ({
   },
 }));
 
-import { put } from '../src/api.js';
+import { get, put } from '../src/api.js';
 import { projectArchive } from '../src/commands/project-archive.js';
 
+const mockedGet = vi.mocked(get);
 const mockedPut = vi.mocked(put);
 
 describe('projectArchive command', () => {
@@ -28,13 +30,14 @@ describe('projectArchive command', () => {
 
     await expect(projectArchive([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-archive <project_id>');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-archive <project>');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
   });
 
-  it('exits on non-numeric project ID', async () => {
+  it('exits when project name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
@@ -42,7 +45,7 @@ describe('projectArchive command', () => {
 
     await expect(projectArchive(['abc'])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(logSpy).toHaveBeenCalledWith('Project "abc" not found.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
@@ -54,11 +57,47 @@ describe('projectArchive command', () => {
 
     await projectArchive(['456']);
 
+    expect(mockedGet).not.toHaveBeenCalled();
     expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
       active: false,
     });
     expect(logSpy).toHaveBeenCalledWith('Project 456 archived.');
     logSpy.mockRestore();
+  });
+
+  it('archives project by name', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
+    mockedPut.mockResolvedValue({ id: 456 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectArchive(['Backend']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      active: false,
+    });
+    expect(logSpy).toHaveBeenCalledWith('Project 456 archived.');
+    logSpy.mockRestore();
+  });
+
+  it('exits on ambiguous project name', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'backend' },
+    ]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectArchive(['Backend'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multiple projects match "Backend". Use the numeric project ID:\n  456  Backend\n  789  backend'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('handles 404 error gracefully', async () => {

--- a/tests/project-delete.test.ts
+++ b/tests/project-delete.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
   del: vi.fn(),
 }));
 
@@ -10,10 +11,11 @@ vi.mock('../src/config.js', () => ({
   },
 }));
 
-import { del } from '../src/api.js';
+import { del, get } from '../src/api.js';
 import { projectDelete } from '../src/commands/project-delete.js';
 
 const mockedDel = vi.mocked(del);
+const mockedGet = vi.mocked(get);
 
 describe('projectDelete command', () => {
   beforeEach(() => {
@@ -28,13 +30,14 @@ describe('projectDelete command', () => {
 
     await expect(projectDelete([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-delete <project_id>');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-delete <project>');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
   });
 
-  it('exits on non-numeric project ID', async () => {
+  it('exits when project name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
@@ -42,7 +45,7 @@ describe('projectDelete command', () => {
 
     await expect(projectDelete(['abc'])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(logSpy).toHaveBeenCalledWith('Project "abc" not found.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
@@ -54,9 +57,43 @@ describe('projectDelete command', () => {
 
     await projectDelete(['456']);
 
+    expect(mockedGet).not.toHaveBeenCalled();
     expect(mockedDel).toHaveBeenCalledWith('/workspaces/123/projects/456');
     expect(logSpy).toHaveBeenCalledWith('Project 456 deleted.');
     logSpy.mockRestore();
+  });
+
+  it('deletes project by name', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
+    mockedDel.mockResolvedValue(undefined);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectDelete(['Backend']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(mockedDel).toHaveBeenCalledWith('/workspaces/123/projects/456');
+    expect(logSpy).toHaveBeenCalledWith('Project 456 deleted.');
+    logSpy.mockRestore();
+  });
+
+  it('exits on ambiguous project name', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'backend' },
+    ]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectDelete(['Backend'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multiple projects match "Backend". Use the numeric project ID:\n  456  Backend\n  789  backend'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('handles 404 error gracefully', async () => {

--- a/tests/project-edit.test.ts
+++ b/tests/project-edit.test.ts
@@ -40,14 +40,15 @@ describe('projectEdit command', () => {
     await expect(projectEdit([])).rejects.toThrow('exit');
 
     expect(errorSpy).toHaveBeenCalledWith(
-      'Usage: tgp project-edit <project_id> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]'
+      'Usage: tgp project-edit <project> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]'
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     errorSpy.mockRestore();
   });
 
-  it('exits with error when project ID is not numeric', async () => {
+  it('exits when project name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
@@ -55,7 +56,7 @@ describe('projectEdit command', () => {
 
     await expect(projectEdit(['abc', '-n', 'New Project'])).rejects.toThrow('exit');
 
-    expect(errorSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(errorSpy).toHaveBeenCalledWith('Project "abc" not found.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     errorSpy.mockRestore();
@@ -127,10 +128,25 @@ describe('projectEdit command', () => {
 
     await projectEdit(['456', '-n', 'New Project']);
 
+    expect(mockedGet).not.toHaveBeenCalled();
     expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
       name: 'New Project',
     });
     expect(mockedPut.mock.calls[0][1]).not.toHaveProperty('is_private');
+    logSpy.mockRestore();
+  });
+
+  it('updates project by name', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
+    mockedPut.mockResolvedValue(updatedProject);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectEdit(['Backend', '-n', 'New Project']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      name: 'New Project',
+    });
     logSpy.mockRestore();
   });
 
@@ -267,6 +283,26 @@ describe('projectEdit command', () => {
 
     expect(errorSpy).toHaveBeenCalledWith(
       'Multiple clients match "Acme Corp":\n  50  Acme Corp\n  51  acme corp'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits on ambiguous project name match', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'backend' },
+    ]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['Backend', '-n', 'New Project'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multiple projects match "Backend". Use the numeric project ID:\n  456  Backend\n  789  backend'
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();

--- a/tests/project-rename.test.ts
+++ b/tests/project-rename.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
   put: vi.fn(),
 }));
 
@@ -10,9 +11,10 @@ vi.mock('../src/config.js', () => ({
   },
 }));
 
-import { put } from '../src/api.js';
+import { get, put } from '../src/api.js';
 import { projectRename } from '../src/commands/project-rename.js';
 
+const mockedGet = vi.mocked(get);
 const mockedPut = vi.mocked(put);
 
 describe('projectRename command', () => {
@@ -28,7 +30,7 @@ describe('projectRename command', () => {
 
     await expect(projectRename([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-rename <project_id> "New Name"');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-rename <project> "New Name"');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
@@ -42,13 +44,14 @@ describe('projectRename command', () => {
 
     await expect(projectRename(['123'])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-rename <project_id> "New Name"');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-rename <project> "New Name"');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
   });
 
-  it('exits with error when project ID is not numeric', async () => {
+  it('exits when project name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
@@ -56,7 +59,7 @@ describe('projectRename command', () => {
 
     await expect(projectRename(['abc', 'New Name'])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(logSpy).toHaveBeenCalledWith('Project "abc" not found.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
@@ -68,11 +71,47 @@ describe('projectRename command', () => {
 
     await projectRename(['456', 'New Name']);
 
+    expect(mockedGet).not.toHaveBeenCalled();
     expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
       name: 'New Name',
     });
     expect(logSpy).toHaveBeenCalledWith('Project 456 renamed to "New Name"');
     logSpy.mockRestore();
+  });
+
+  it('renames project by name', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
+    mockedPut.mockResolvedValue({ id: 456, name: 'New Name' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectRename(['Backend', 'New Name']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      name: 'New Name',
+    });
+    expect(logSpy).toHaveBeenCalledWith('Project 456 renamed to "New Name"');
+    logSpy.mockRestore();
+  });
+
+  it('exits on ambiguous project name', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'backend' },
+    ]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRename(['Backend', 'New Name'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multiple projects match "Backend". Use the numeric project ID:\n  456  Backend\n  789  backend'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('handles 404 error gracefully', async () => {

--- a/tests/project-restore.test.ts
+++ b/tests/project-restore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
   put: vi.fn(),
 }));
 
@@ -10,9 +11,10 @@ vi.mock('../src/config.js', () => ({
   },
 }));
 
-import { put } from '../src/api.js';
+import { get, put } from '../src/api.js';
 import { projectRestore } from '../src/commands/project-restore.js';
 
+const mockedGet = vi.mocked(get);
 const mockedPut = vi.mocked(put);
 
 describe('projectRestore command', () => {
@@ -28,13 +30,14 @@ describe('projectRestore command', () => {
 
     await expect(projectRestore([])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-restore <project_id>');
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp project-restore <project>');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
   });
 
-  it('exits on non-numeric project ID', async () => {
+  it('exits when project name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');
     });
@@ -42,7 +45,7 @@ describe('projectRestore command', () => {
 
     await expect(projectRestore(['abc'])).rejects.toThrow('exit');
 
-    expect(logSpy).toHaveBeenCalledWith('Invalid project ID: "abc". Must be a number.');
+    expect(logSpy).toHaveBeenCalledWith('Project "abc" not found.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     logSpy.mockRestore();
@@ -54,11 +57,47 @@ describe('projectRestore command', () => {
 
     await projectRestore(['456']);
 
+    expect(mockedGet).not.toHaveBeenCalled();
     expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
       active: true,
     });
     expect(logSpy).toHaveBeenCalledWith('Project 456 restored.');
     logSpy.mockRestore();
+  });
+
+  it('restores project by name', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
+    mockedPut.mockResolvedValue({ id: 456 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await projectRestore(['Backend']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+    expect(mockedPut).toHaveBeenCalledWith('/workspaces/123/projects/456', {
+      active: true,
+    });
+    expect(logSpy).toHaveBeenCalledWith('Project 456 restored.');
+    logSpy.mockRestore();
+  });
+
+  it('exits on ambiguous project name', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'backend' },
+    ]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectRestore(['Backend'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Multiple projects match "Backend". Use the numeric project ID:\n  456  Backend\n  789  backend'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('handles 404 error gracefully', async () => {

--- a/tests/projects.test.ts
+++ b/tests/projects.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
+}));
+
+import { get } from '../src/api.js';
+import { resolveProjectId } from '../src/projects.js';
+
+const mockedGet = vi.mocked(get);
+
+describe('resolveProjectId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns numeric project input without fetching projects', async () => {
+    await expect(resolveProjectId(123, '456')).resolves.toBe(456);
+
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it('resolves an exact project name case-insensitively', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'Frontend' },
+    ]);
+
+    await expect(resolveProjectId(123, 'backend')).resolves.toBe(456);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/projects');
+  });
+
+  it('fails when the project name is not found', async () => {
+    mockedGet.mockResolvedValue([{ id: 456, name: 'Backend' }]);
+
+    await expect(resolveProjectId(123, 'Missing')).rejects.toThrow('Project "Missing" not found.');
+  });
+
+  it('fails when multiple projects match case-insensitively', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Backend' },
+      { id: 789, name: 'backend' },
+    ]);
+
+    await expect(resolveProjectId(123, 'Backend')).rejects.toThrow(
+      'Multiple projects match "Backend". Use the numeric project ID:\n  456  Backend\n  789  backend'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add shared project ID/name resolution for project maintenance commands
- allow project edit/rename/delete/archive/restore to accept exact project names
- document ID-or-name project arguments, quote rules, numeric-name behavior, and ambiguity handling

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run format:check
- npm run lint:md
- git diff --check

Closes #136