### PR TITLE
feat: add client-list command (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Run `tgp` without arguments to see all available commands.
 
 ### Clients
 
-Coming soon — `client-list`, `client-add`, `client-rename`, `client-delete`.
+| Command           | Description            | Docs                                       |
+| ----------------- | ---------------------- | ------------------------------------------ |
+| `tgp client-list` | List workspace clients | [docs/client-list.md](docs/client-list.md) |
 
 ### Projects
 

--- a/docs/client-list.md
+++ b/docs/client-list.md
@@ -1,0 +1,40 @@
+# `client-list` — List Clients
+
+Lists clients in your workspace with IDs, names, notes, and status.
+
+## Usage
+
+```bash
+tgp client-list
+tgp client-list --status active
+tgp client-list --status archived
+tgp client-list --status both
+tgp client-list --name Acme
+```
+
+## Options
+
+| Option                            | Description                                  |
+| --------------------------------- | -------------------------------------------- |
+| `--status active\|archived\|both` | Filter by client status. Defaults to active. |
+| `--name <filter>`                 | Case-insensitive client name filter.         |
+
+## Output
+
+```text
+Clients in workspace 21355416
+
+  ID           Name                           Notes                Status
+  ──────────── ────────────────────────────── ──────────────────── ────────
+  123456789    Acme Corp                      Main client          active
+  123456790    Beta Inc                       —                    active
+```
+
+## Columns
+
+| Column | Description                   |
+| ------ | ----------------------------- |
+| ID     | Toggl client ID               |
+| Name   | Client name                   |
+| Notes  | Client notes, or `—` if blank |
+| Status | `active` or `archived`        |

--- a/src/commands/client-list.ts
+++ b/src/commands/client-list.ts
@@ -1,0 +1,94 @@
+import { get } from '../api.js';
+import { config } from '../config.js';
+import { DASH, parseOrExit } from '../utils.js';
+
+type ClientStatus = 'active' | 'archived' | 'both';
+
+interface ClientListItem {
+  id: number;
+  name: string;
+  notes?: string | null;
+  wid: number;
+  archived: boolean;
+  at: string;
+}
+
+interface ClientListArgs {
+  status: ClientStatus;
+  name?: string;
+}
+
+const USAGE = 'Usage: tgp client-list [--status active|archived|both] [--name <filter>]';
+
+function isClientStatus(value: string): value is ClientStatus {
+  return value === 'active' || value === 'archived' || value === 'both';
+}
+
+export function parseArgs(args: string[]): ClientListArgs {
+  const parsed: ClientListArgs = { status: 'active' };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--status') {
+      const status = args[++i];
+      if (!status || !isClientStatus(status)) {
+        throw new Error(USAGE);
+      }
+      parsed.status = status;
+      continue;
+    }
+
+    if (arg === '--name') {
+      const name = args[++i];
+      if (!name) {
+        throw new Error(USAGE);
+      }
+      parsed.name = name;
+      continue;
+    }
+
+    throw new Error(USAGE);
+  }
+
+  return parsed;
+}
+
+function filterByStatus(clients: ClientListItem[], status: ClientStatus): ClientListItem[] {
+  if (status === 'both') {
+    return clients;
+  }
+
+  return clients.filter((client) => client.archived === (status === 'archived'));
+}
+
+export async function clientList(args: string[] = []) {
+  const { status, name } = parseOrExit(() => parseArgs(args));
+  const wsId = await config.getWorkspaceId();
+  const params = new URLSearchParams({ status });
+
+  if (name) {
+    params.set('name', name);
+  }
+
+  const list = await get<ClientListItem[]>(`/workspaces/${wsId}/clients?${params.toString()}`);
+  const clients = filterByStatus(list, status);
+
+  if (clients.length === 0) {
+    console.log('No clients found');
+    return;
+  }
+
+  console.log(`\nClients in workspace ${wsId}\n`);
+  console.log(`  ${'ID'.padEnd(12)} ${'Name'.padEnd(30)} ${'Notes'.padEnd(20)} Status`);
+  console.log(`  ${''.padEnd(12, '─')} ${''.padEnd(30, '─')} ${''.padEnd(20, '─')} ${''.padEnd(8, '─')}`);
+
+  for (const client of clients) {
+    const notes = client.notes?.trim() ? client.notes : DASH;
+    const statusLabel = client.archived ? 'archived' : 'active';
+    const line = `  ${String(client.id).padEnd(12)} ${client.name.slice(0, 30).padEnd(30)} ${notes.slice(0, 20).padEnd(20)} ${statusLabel}`;
+    console.log(line);
+  }
+
+  console.log();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { hasConfig, ConfigNotFoundError } from './config.js';
 import { entryList } from './commands/entry-list.js';
 import { week } from './commands/week.js';
 import { projectList } from './commands/project-list.js';
+import { clientList } from './commands/client-list.js';
 import { workspaceList } from './commands/workspace-list.js';
 import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
@@ -59,6 +60,9 @@ if (command === 'auth') {
     case 'project-list':
       projectList(args);
       break;
+    case 'client-list':
+      clientList(args);
+      break;
     case 'workspace-list':
       workspaceList();
       break;
@@ -111,6 +115,7 @@ if (command === 'auth') {
       console.error('  workspace-list');
       console.error('  track            stop             entry-edit       entry-list       entry-delete');
       console.error('  week');
+      console.error('  client-list');
       console.error('  project-list     project-create   project-edit     project-rename   project-archive');
       console.error('  project-restore  project-delete');
       console.error('  tag-list         tag-create       tag-rename       tag-delete');

--- a/tests/client-list-parseArgs.test.ts
+++ b/tests/client-list-parseArgs.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseArgs } from '../src/commands/client-list.js';
+
+const usage = 'Usage: tgp client-list [--status active|archived|both] [--name <filter>]';
+
+describe('client-list parseArgs', () => {
+  it('defaults to active clients', () => {
+    expect(parseArgs([])).toEqual({ status: 'active' });
+  });
+
+  it('accepts active status', () => {
+    expect(parseArgs(['--status', 'active'])).toEqual({ status: 'active' });
+  });
+
+  it('accepts archived status', () => {
+    expect(parseArgs(['--status', 'archived'])).toEqual({ status: 'archived' });
+  });
+
+  it('accepts both status', () => {
+    expect(parseArgs(['--status', 'both'])).toEqual({ status: 'both' });
+  });
+
+  it('accepts a name filter', () => {
+    expect(parseArgs(['--name', 'Acme'])).toEqual({ status: 'active', name: 'Acme' });
+  });
+
+  it('accepts status and name in either order', () => {
+    expect(parseArgs(['--status', 'both', '--name', 'Acme'])).toEqual({ status: 'both', name: 'Acme' });
+    expect(parseArgs(['--name', 'Acme', '--status', 'archived'])).toEqual({
+      status: 'archived',
+      name: 'Acme',
+    });
+  });
+
+  it('throws usage when status is missing', () => {
+    expect(() => parseArgs(['--status'])).toThrow(usage);
+  });
+
+  it('throws usage when status is invalid', () => {
+    expect(() => parseArgs(['--status', 'deleted'])).toThrow(usage);
+  });
+
+  it('throws usage when name is missing', () => {
+    expect(() => parseArgs(['--name'])).toThrow(usage);
+  });
+
+  it('throws usage on unknown flag', () => {
+    expect(() => parseArgs(['--all'])).toThrow(usage);
+  });
+});

--- a/tests/client-list.test.ts
+++ b/tests/client-list.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { get } from '../src/api.js';
+import { clientList } from '../src/commands/client-list.js';
+
+const mockedGet = vi.mocked(get);
+
+describe('clientList command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests active clients by default', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Acme Corp', notes: 'Main client', wid: 123, archived: false, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList([]);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/clients?status=active');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Acme Corp'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Main client'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('active'));
+    logSpy.mockRestore();
+  });
+
+  it('requests archived clients with --status archived', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 789, name: 'Old Client', notes: 'Done', wid: 123, archived: true, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList(['--status', 'archived']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/clients?status=archived');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Old Client'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Done'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('archived'));
+    logSpy.mockRestore();
+  });
+
+  it('filters active clients from archived output defensively', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Acme Corp', notes: 'Main client', wid: 123, archived: false, at: '' },
+      { id: 789, name: 'Old Client', notes: 'Done', wid: 123, archived: true, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList(['--status', 'archived']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/clients?status=archived');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Old Client'));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('Acme Corp'));
+    logSpy.mockRestore();
+  });
+
+  it('includes encoded status and name query params', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Acme & Sons', notes: 'Main client', wid: 123, archived: false, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList(['--status', 'both', '--name', 'Acme & Sons']);
+
+    expect(mockedGet).toHaveBeenCalledWith('/workspaces/123/clients?status=both&name=Acme+%26+Sons');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Acme & Sons'));
+    logSpy.mockRestore();
+  });
+
+  it('prints a dash for blank notes', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Acme Corp', notes: '  ', wid: 123, archived: false, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList([]);
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('—'));
+    logSpy.mockRestore();
+  });
+
+  it('prints a message when no clients are rendered', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 789, name: 'Old Client', notes: null, wid: 123, archived: true, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList([]);
+
+    expect(logSpy).toHaveBeenCalledWith('No clients found');
+    logSpy.mockRestore();
+  });
+});

--- a/tests/client-list.test.ts
+++ b/tests/client-list.test.ts
@@ -90,6 +90,20 @@ describe('clientList command', () => {
     logSpy.mockRestore();
   });
 
+  it('prints a dash for null or missing notes', async () => {
+    mockedGet.mockResolvedValue([
+      { id: 456, name: 'Null Notes', notes: null, wid: 123, archived: false, at: '' },
+      { id: 457, name: 'Missing Notes', wid: 123, archived: false, at: '' },
+    ]);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientList([]);
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/Null Notes\s+—\s+active/));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/Missing Notes\s+—\s+active/));
+    logSpy.mockRestore();
+  });
+
   it('prints a message when no clients are rendered', async () => {
     mockedGet.mockResolvedValue([
       { id: 789, name: 'Old Client', notes: null, wid: 123, archived: true, at: '' },


### PR DESCRIPTION
## Summary

Adds `tgp client-list` to list Toggl Track clients for the configured workspace.

## Changes

- Adds `client-list` with `--status active|archived|both` and `--name <filter>`.
- Defaults status to `active` and delegates name filtering to the Toggl API.
- Renders ID, name, notes, and active/archived status.
- Documents the command and adds focused parser/command tests.

Closes #26.

## Validation

- `npm test -- client-list`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run lint:md`
- `npm run format:check`