### PR TITLE
feat: add --date flag to track command for past entries (#148)

### DIFF
--- a/docs/track.md
+++ b/docs/track.md
@@ -5,7 +5,7 @@ Starts a running timer or logs a completed time entry with project and tags.
 ## Usage
 
 ```bash
-tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]
+tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m] [-d YYYY-MM-DD|yesterday]
 ```
 
 ## Running Timer
@@ -28,14 +28,26 @@ tgp track "Code review" -p "Dev-Pilot" --at 10:00 --dur 1h
 tgp track "Bug fix" -p "Dev-Pilot" -t dev,bug --at 14:00 --dur 1h30m
 ```
 
+## Log Entry for a Past Day
+
+Add `--date` (or `-d`) with an ISO date or `yesterday`:
+
+```bash
+tgp track "Morning standup" --at 09:00 --dur 30m --date yesterday
+tgp track "Bug fix" -p "Dev-Pilot" --at 14:00 --dur 1h --date 2025-06-05
+```
+
+`--date` requires both `--at` and `--dur` (you cannot start a running timer in the past).
+
 ## Options
 
-| Flag        | Short | Description                                            |
-| ----------- | ----- | ------------------------------------------------------ |
-| `--project` | `-p`  | Project name (case-insensitive)                        |
-| `--tags`    | `-t`  | Comma-separated tag names                              |
-| `--at`      |       | Start time in HH:MM format (today) — requires `--dur`  |
-| `--dur`     |       | Duration (e.g. `30m`, `1h`, `1h30m`) — requires `--at` |
+| Flag        | Short | Description                                                    |
+| ----------- | ----- | -------------------------------------------------------------- |
+| `--project` | `-p`  | Project name (case-insensitive)                                |
+| `--tags`    | `-t`  | Comma-separated tag names                                      |
+| `--at`      |       | Start time in HH:MM format — requires `--dur`                  |
+| `--dur`     |       | Duration (e.g. `30m`, `1h`, `1h30m`) — requires `--at`         |
+| `--date`    | `-d`  | Date (`YYYY-MM-DD` or `yesterday`) — requires `--at` + `--dur` |
 
 ## Project Lookup
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -18,7 +18,7 @@ interface TimeEntry {
   workspace_id: number;
 }
 
-const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '--at', '--dur']);
+const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '--at', '--dur', '-d', '--date']);
 
 export function parseArgs(args: string[]): {
   description: string;
@@ -26,16 +26,20 @@ export function parseArgs(args: string[]): {
   tags: string[];
   at: string | null;
   dur: string | null;
+  date: string | null;
 } {
   let description = '';
   let project: string | null = null;
   let tags: string[] = [];
   let at: string | null = null;
   let dur: string | null = null;
+  let date: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('-') && !VALID_FLAGS.has(args[i])) {
-      throw new Error(`Unknown flag: ${args[i]}. Valid flags: -p/--project, -t/--tags, --at, --dur`);
+      throw new Error(
+        `Unknown flag: ${args[i]}. Valid flags: -p/--project, -t/--tags, --at, --dur, -d/--date`
+      );
     }
 
     if ((args[i] === '-p' || args[i] === '--project') && args[i + 1]) {
@@ -46,6 +50,8 @@ export function parseArgs(args: string[]): {
       at = args[++i];
     } else if (args[i] === '--dur' && args[i + 1]) {
       dur = args[++i];
+    } else if ((args[i] === '-d' || args[i] === '--date') && args[i + 1]) {
+      date = args[++i];
     } else if (!args[i].startsWith('-')) {
       description = args[i];
     }
@@ -53,15 +59,22 @@ export function parseArgs(args: string[]): {
 
   if (!description) {
     throw new Error(
-      'Usage: tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m]'
+      'Usage: tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m] [-d YYYY-MM-DD|yesterday]'
     );
   }
 
-  return { description, project, tags, at, dur };
+  return { description, project, tags, at, dur, date };
 }
 
 export async function track(args: string[]) {
-  const { description, project: projectName, tags, at, dur } = parseOrExit(() => parseArgs(args));
+  const {
+    description,
+    project: projectName,
+    tags,
+    at,
+    dur,
+    date: rawDate,
+  } = parseOrExit(() => parseArgs(args));
   const wsId = await config.getWorkspaceId();
 
   let projectId: number | null = null;
@@ -86,7 +99,23 @@ export async function track(args: string[]) {
     process.exit(1);
   }
 
-  const startTime = at ? buildStartTime(at) : new Date().toISOString();
+  if (rawDate !== null && !isTimed) {
+    console.error('--date requires both --at and --dur (cannot start a running timer in the past).');
+    process.exit(1);
+  }
+
+  const resolvedDate =
+    rawDate === 'yesterday' ? new Date(Date.now() - 86400000).toISOString().split('T')[0] : rawDate;
+
+  if (resolvedDate !== null) {
+    const d = new Date(resolvedDate + 'T12:00:00');
+    if (isNaN(d.getTime())) {
+      console.error(`Invalid date: ${rawDate}. Use YYYY-MM-DD or "yesterday".`);
+      process.exit(1);
+    }
+  }
+
+  const startTime = at ? buildStartTime(at, resolvedDate ?? undefined) : new Date().toISOString();
   const duration = dur ? parseDuration(dur) : -1;
 
   const entry = await post<TimeEntry>(`/workspaces/${wsId}/time_entries`, {

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -2,6 +2,15 @@ import { config } from '../config.js';
 import { get, post } from '../api.js';
 import { parseDuration, buildStartTime, parseOrExit } from '../utils.js';
 
+function formatLocalYesterday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 interface Project {
   id: number;
   name: string;
@@ -104,8 +113,7 @@ export async function track(args: string[]) {
     process.exit(1);
   }
 
-  const resolvedDate =
-    rawDate === 'yesterday' ? new Date(Date.now() - 86400000).toISOString().split('T')[0] : rawDate;
+  const resolvedDate = rawDate === 'yesterday' ? formatLocalYesterday() : rawDate;
 
   if (resolvedDate !== null) {
     const d = new Date(resolvedDate + 'T12:00:00');

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -69,7 +69,10 @@ export function parseArgs(args: string[]): {
       at = args[++i];
     } else if (args[i] === '--dur' && args[i + 1]) {
       dur = args[++i];
-    } else if ((args[i] === '-d' || args[i] === '--date') && args[i + 1]) {
+    } else if (args[i] === '-d' || args[i] === '--date') {
+      if (!args[i + 1] || args[i + 1].startsWith('-')) {
+        throw new Error(`Missing value for ${args[i]}. Use YYYY-MM-DD or "yesterday".`);
+      }
       date = args[++i];
     } else if (!args[i].startsWith('-')) {
       description = args[i];

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -2,6 +2,16 @@ import { config } from '../config.js';
 import { get, post } from '../api.js';
 import { parseDuration, buildStartTime, parseOrExit } from '../utils.js';
 
+function isValidCalendarDate(s: string): boolean {
+  const match = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  const y = parseInt(match[1], 10);
+  const m = parseInt(match[2], 10);
+  const d = parseInt(match[3], 10);
+  const dt = new Date(y, m - 1, d);
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
+}
+
 function formatLocalYesterday(): string {
   const d = new Date();
   d.setDate(d.getDate() - 1);
@@ -115,12 +125,9 @@ export async function track(args: string[]) {
 
   const resolvedDate = rawDate === 'yesterday' ? formatLocalYesterday() : rawDate;
 
-  if (resolvedDate !== null) {
-    const d = new Date(resolvedDate + 'T12:00:00');
-    if (isNaN(d.getTime())) {
-      console.error(`Invalid date: ${rawDate}. Use YYYY-MM-DD or "yesterday".`);
-      process.exit(1);
-    }
+  if (resolvedDate !== null && !isValidCalendarDate(resolvedDate)) {
+    console.error(`Invalid date: ${rawDate}. Use YYYY-MM-DD or "yesterday".`);
+    process.exit(1);
   }
 
   const startTime = at ? buildStartTime(at, resolvedDate ?? undefined) : new Date().toISOString();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,9 +39,9 @@ export function formatTime(iso: string): string {
   });
 }
 
-export function buildStartTime(at: string): string {
-  const today = new Date().toISOString().split('T')[0];
-  const d = new Date(`${today}T${at}:00`);
+export function buildStartTime(at: string, date?: string): string {
+  const day = date ?? new Date().toISOString().split('T')[0];
+  const d = new Date(`${day}T${at}:00`);
   if (isNaN(d.getTime())) throw new Error(`Invalid time: ${at}. Use HH:MM format.`);
   return d.toISOString();
 }

--- a/tests/track-parseArgs.test.ts
+++ b/tests/track-parseArgs.test.ts
@@ -97,6 +97,18 @@ describe('track parseArgs', () => {
     });
   });
 
+  it('throws on --date with no value', () => {
+    expect(() => parseArgs(['Work', '--at', '09:00', '--dur', '30m', '--date'])).toThrow(
+      'Missing value for --date'
+    );
+  });
+
+  it('throws on -d followed by another flag', () => {
+    expect(() => parseArgs(['Work', '--at', '09:00', '--dur', '30m', '-d', '-p', 'X'])).toThrow(
+      'Missing value for -d'
+    );
+  });
+
   it('throws on unknown flag', () => {
     expect(() => parseArgs(['Work', '--unknown'])).toThrow('Unknown flag');
   });

--- a/tests/track-parseArgs.test.ts
+++ b/tests/track-parseArgs.test.ts
@@ -10,6 +10,7 @@ describe('track parseArgs', () => {
       tags: [],
       at: null,
       dur: null,
+      date: null,
     });
   });
 
@@ -58,6 +59,41 @@ describe('track parseArgs', () => {
       tags: ['meeting', 'planning'],
       at: '10:00',
       dur: '1h',
+      date: null,
+    });
+  });
+
+  it('parses -d with ISO date', () => {
+    const result = parseArgs(['Standup', '--at', '09:00', '--dur', '30m', '-d', '2025-06-10']);
+    expect(result.date).toBe('2025-06-10');
+  });
+
+  it('parses --date with yesterday keyword', () => {
+    const result = parseArgs(['Standup', '--at', '09:00', '--dur', '30m', '--date', 'yesterday']);
+    expect(result.date).toBe('yesterday');
+  });
+
+  it('parses all flags with --date', () => {
+    const result = parseArgs([
+      'Standup',
+      '-p',
+      'Dev-Pilot',
+      '-t',
+      'meeting',
+      '--at',
+      '09:00',
+      '--dur',
+      '30m',
+      '--date',
+      'yesterday',
+    ]);
+    expect(result).toEqual({
+      description: 'Standup',
+      project: 'Dev-Pilot',
+      tags: ['meeting'],
+      at: '09:00',
+      dur: '30m',
+      date: 'yesterday',
     });
   });
 

--- a/tests/track.test.ts
+++ b/tests/track.test.ts
@@ -161,6 +161,32 @@ describe('track command', () => {
     exitSpy.mockRestore();
   });
 
+  it('exits on impossible calendar date (Feb 31)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    await expect(track(['Work', '--at', '09:00', '--dur', '30m', '--date', '2025-02-31'])).rejects.toThrow(
+      'exit'
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits on malformed date (MM-DD-YYYY)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    await expect(track(['Work', '--at', '09:00', '--dur', '30m', '--date', '06-15-2025'])).rejects.toThrow(
+      'exit'
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
   it('creates a timed entry with --date for a specific date', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-06-15T12:00:00'));

--- a/tests/track.test.ts
+++ b/tests/track.test.ts
@@ -218,4 +218,33 @@ describe('track command', () => {
 
     vi.useRealTimers();
   });
+
+  it('yesterday resolves correctly around midnight (local calendar)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T00:30:00'));
+
+    mockedPost.mockResolvedValue({
+      id: 3002,
+      description: 'Late work',
+      start: expect.any(String),
+      duration: 1800,
+      project_id: null,
+      project_name: null,
+      tags: null,
+      workspace_id: 123,
+    });
+
+    await track(['Late work', '--at', '23:30', '--dur', '30m', '-d', 'yesterday']);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({
+        start: new Date('2025-06-14T23:30:00').toISOString(),
+        duration: 30 * 60,
+        description: 'Late work',
+      })
+    );
+
+    vi.useRealTimers();
+  });
 });

--- a/tests/track.test.ts
+++ b/tests/track.test.ts
@@ -138,4 +138,84 @@ describe('track command', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
   });
+
+  it('exits when --date is provided without --at and --dur', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    await expect(track(['Work', '--date', 'yesterday'])).rejects.toThrow('exit');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits on invalid date value', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    await expect(track(['Work', '--at', '09:00', '--dur', '30m', '--date', 'foo'])).rejects.toThrow('exit');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('creates a timed entry with --date for a specific date', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T12:00:00'));
+
+    mockedPost.mockResolvedValue({
+      id: 3000,
+      description: 'Standup',
+      start: expect.any(String),
+      duration: 1800,
+      project_id: null,
+      project_name: null,
+      tags: null,
+      workspace_id: 123,
+    });
+
+    await track(['Standup', '--at', '09:00', '--dur', '30m', '--date', '2025-06-10']);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({
+        start: new Date('2025-06-10T09:00:00').toISOString(),
+        duration: 30 * 60,
+        description: 'Standup',
+      })
+    );
+
+    vi.useRealTimers();
+  });
+
+  it('creates a timed entry with --date yesterday', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T12:00:00'));
+
+    mockedPost.mockResolvedValue({
+      id: 3001,
+      description: 'Review',
+      start: expect.any(String),
+      duration: 3600,
+      project_id: null,
+      project_name: null,
+      tags: null,
+      workspace_id: 123,
+    });
+
+    await track(['Review', '--at', '14:00', '--dur', '1h', '-d', 'yesterday']);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({
+        start: new Date('2025-06-14T14:00:00').toISOString(),
+        duration: 3600,
+        description: 'Review',
+      })
+    );
+
+    vi.useRealTimers();
+  });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -107,6 +107,18 @@ describe('buildStartTime', () => {
   it('throws on non-HH:MM input', () => {
     expect(() => buildStartTime('abc')).toThrow('Invalid time');
   });
+
+  it('builds ISO string for a specific date', () => {
+    const result = buildStartTime('09:00', '2025-06-10');
+    const expected = new Date('2025-06-10T09:00:00').toISOString();
+    expect(result).toBe(expected);
+  });
+
+  it('builds ISO string for yesterday date', () => {
+    const result = buildStartTime('14:30', '2025-06-14');
+    const expected = new Date('2025-06-14T14:30:00').toISOString();
+    expect(result).toBe(expected);
+  });
 });
 
 describe('parseDateArg', () => {


### PR DESCRIPTION
## Summary

Adds `--date` / `-d` flag to the `track` command, allowing users to log time entries for past days.

Closes #148

## Usage

```bash
tgp track "Morning standup" --at 09:00 --dur 30m --date yesterday
tgp track "Bug fix" -p "Dev-Pilot" --at 14:00 --dur 1h --date 2025-06-05
```

## Changes

- `buildStartTime` in `src/utils.ts` now accepts an optional `date` param
- `parseArgs` and `track` in `src/commands/track.ts` support `--date` / `-d` flag
- Validates: `--date` requires both `--at` and `--dur`; invalid dates get a clear error
- Resolves `yesterday` keyword to the previous day's date
- Updated `docs/track.md` with new section and options table entry

## Tests

- `tests/utils.test.ts` — 2 new tests for `buildStartTime` with date param
- `tests/track-parseArgs.test.ts` — 3 new tests for `--date` / `-d` parsing
- `tests/track.test.ts` — 4 new tests: invalid date, missing `--at`/`--dur`, specific date, `yesterday`