### PR TITLE
feat: support 'yesterday' in -d/--date for entry-list and week (#151)

### DIFF
--- a/docs/entry-list.md
+++ b/docs/entry-list.md
@@ -6,6 +6,7 @@ Lists all time entries for a given day with totals by project.
 
 ```bash
 tgp entry-list                        # today
+tgp entry-list -d yesterday           # yesterday
 tgp entry-list -d 2026-04-29          # specific date
 tgp entry-list --date 2026-04-29      # long form
 ```

--- a/docs/week.md
+++ b/docs/week.md
@@ -9,6 +9,7 @@ tgp week                     # current week
 tgp week --week -1           # last week
 tgp week --week -3           # 3 weeks ago
 tgp week --date 2026-04-01   # week containing Apr 1
+tgp week -d yesterday        # week containing yesterday
 tgp week --verbose           # current week with daily breakdown
 tgp week -v --week -1        # last week with daily breakdown
 ```
@@ -18,7 +19,7 @@ tgp week -v --week -1        # last week with daily breakdown
 | Flag                | Shorthand       | Description                                                        |
 | ------------------- | --------------- | ------------------------------------------------------------------ |
 | `--week N`          | `-w N`          | Relative week offset (0 = current, -1 = last, 2 = two weeks ahead) |
-| `--date YYYY-MM-DD` | `-d YYYY-MM-DD` | Show the week containing the given date                            |
+| `--date YYYY-MM-DD` | `-d YYYY-MM-DD` | Show the week containing the given date (also accepts `yesterday`) |
 | `--verbose`         | `-v`            | Show a per-day breakdown matrix for each project                   |
 
 `--date` and `--week` are mutually exclusive. `--verbose` can be combined with either.

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js';
 import { get, post } from '../api.js';
-import { parseDuration, buildStartTime, parseOrExit } from '../utils.js';
+import { parseDuration, buildStartTime, parseOrExit, localYesterdayDate, formatLocalDate } from '../utils.js';
 
 function isValidCalendarDate(s: string): boolean {
   const match = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -10,15 +10,6 @@ function isValidCalendarDate(s: string): boolean {
   const d = parseInt(match[3], 10);
   const dt = new Date(y, m - 1, d);
   return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
-}
-
-function formatLocalYesterday(): string {
-  const d = new Date();
-  d.setDate(d.getDate() - 1);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
 }
 
 interface Project {
@@ -126,7 +117,7 @@ export async function track(args: string[]) {
     process.exit(1);
   }
 
-  const resolvedDate = rawDate === 'yesterday' ? formatLocalYesterday() : rawDate;
+  const resolvedDate = rawDate === 'yesterday' ? formatLocalDate(localYesterdayDate()) : rawDate;
 
   if (resolvedDate !== null && !isValidCalendarDate(resolvedDate)) {
     console.error(`Invalid date: ${rawDate}. Use YYYY-MM-DD or "yesterday".`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,12 +46,28 @@ export function buildStartTime(at: string, date?: string): string {
   return d.toISOString();
 }
 
+export function localYesterdayDate(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+export function formatLocalDate(d: Date): string {
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 export function parseDateArg(args: string[]): Date {
   const idx = args.indexOf('-d') !== -1 ? args.indexOf('-d') : args.indexOf('--date');
   if (idx !== -1 && args[idx + 1]) {
-    const d = new Date(args[idx + 1] + 'T12:00:00');
+    const val = args[idx + 1];
+    if (val === 'yesterday') return localYesterdayDate();
+    const d = new Date(val + 'T12:00:00');
     if (!isNaN(d.getTime())) return d;
-    throw new Error(`Invalid date: ${args[idx + 1]}`);
+    throw new Error(`Invalid date: ${val}. Use YYYY-MM-DD or "yesterday".`);
   }
   return new Date();
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -7,6 +7,8 @@ import {
   buildStartTime,
   parseDateArg,
   parseOrExit,
+  localYesterdayDate,
+  formatLocalDate,
 } from '../src/utils.js';
 
 describe('formatDuration', () => {
@@ -138,8 +140,67 @@ describe('parseDateArg', () => {
     expect(result.toISOString().slice(0, 10)).toBe('2025-03-20');
   });
 
+  it('parses -d yesterday', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T12:00:00'));
+    const result = parseDateArg(['-d', 'yesterday']);
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(14);
+    vi.useRealTimers();
+  });
+
+  it('yesterday resolves correctly around midnight', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T00:30:00'));
+    const result = parseDateArg(['--date', 'yesterday']);
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(14);
+    vi.useRealTimers();
+  });
+
   it('throws on invalid date', () => {
     expect(() => parseDateArg(['-d', 'not-a-date'])).toThrow('Invalid date');
+  });
+});
+
+describe('localYesterdayDate', () => {
+  it('returns yesterday in local calendar', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T12:00:00'));
+    const result = localYesterdayDate();
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(14);
+    vi.useRealTimers();
+  });
+
+  it('works correctly around midnight', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T00:30:00'));
+    const result = localYesterdayDate();
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(14);
+    vi.useRealTimers();
+  });
+
+  it('works across month boundary', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-03-01T12:00:00'));
+    const result = localYesterdayDate();
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(1);
+    expect(result.getDate()).toBe(28);
+    vi.useRealTimers();
+  });
+});
+
+describe('formatLocalDate', () => {
+  it('formats a date as YYYY-MM-DD using local components', () => {
+    const d = new Date(2025, 5, 14);
+    expect(formatLocalDate(d)).toBe('2025-06-14');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `yesterday` keyword support to `-d`/`--date` flag in `entry-list` and `week` commands, matching the existing behavior in `track`.

Closes #151

## Usage

```bash
tgp entry-list -d yesterday
tgp week -d yesterday
```

## Changes

- Extract `localYesterdayDate()` and `formatLocalDate()` into `src/utils.ts` as shared helpers
- Update `parseDateArg` to resolve `yesterday` before passing to `new Date()`
- Refactor `track.ts` to use the shared helpers instead of its private `formatLocalYesterday()`
- Add tests: `localYesterdayDate` (midnight, month boundary), `formatLocalDate`, `parseDateArg` with `yesterday`
- Update `docs/entry-list.md` and `docs/week.md` with `yesterday` examples