### PR TITLE
fix: require values for CLI flags to prevent silent drops (#150)

### DIFF
--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -104,7 +104,7 @@ export function parseArgs(args: string[]): {
       project = requireFlagValue(args, i, args[i]);
       i++;
     } else if (args[i] === '-t' || args[i] === '--tags') {
-      tags = normalizeTags(requireFlagValue(args, i, args[i]).split(','));
+      tags = normalizeTags(requireFlagValue(args, i, args[i], { allowEmpty: true }).split(','));
       i++;
     } else if (args[i] === '--dur') {
       dur = requireFlagValue(args, i, args[i]);

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -1,5 +1,5 @@
 import { get, put } from '../api.js';
-import { parseDuration, parseOrExit } from '../utils.js';
+import { parseDuration, parseOrExit, requireFlagValue } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -97,14 +97,18 @@ export function parseArgs(args: string[]): {
       );
     }
 
-    if ((args[i] === '-d' || args[i] === '--description') && args[i + 1]) {
-      description = args[++i];
-    } else if ((args[i] === '-p' || args[i] === '--project') && args[i + 1]) {
-      project = args[++i];
-    } else if ((args[i] === '-t' || args[i] === '--tags') && i + 1 < args.length) {
-      tags = normalizeTags(args[++i].split(','));
-    } else if (args[i] === '--dur' && args[i + 1]) {
-      dur = args[++i];
+    if (args[i] === '-d' || args[i] === '--description') {
+      description = requireFlagValue(args, i, args[i]);
+      i++;
+    } else if (args[i] === '-p' || args[i] === '--project') {
+      project = requireFlagValue(args, i, args[i]);
+      i++;
+    } else if (args[i] === '-t' || args[i] === '--tags') {
+      tags = normalizeTags(requireFlagValue(args, i, args[i]).split(','));
+      i++;
+    } else if (args[i] === '--dur') {
+      dur = requireFlagValue(args, i, args[i]);
+      i++;
     } else if (!args[i].startsWith('-') && !id) {
       id = args[i];
     }

--- a/src/commands/project-create.ts
+++ b/src/commands/project-create.ts
@@ -1,7 +1,7 @@
 import { config } from '../config.js';
 import { post } from '../api.js';
 import { resolveClientId } from '../clients.js';
-import { parseOrExit } from '../utils.js';
+import { parseOrExit, requireFlagValue } from '../utils.js';
 
 interface Project {
   id: number;
@@ -24,11 +24,11 @@ function parseArgs(args: string[]) {
     }
 
     if (args[i] === '-c' || args[i] === '--client') {
-      if (!args[i + 1]) throw new Error('--client requires a value.');
-      client = args[++i];
+      client = requireFlagValue(args, i, args[i] === '-c' ? '-c' : '--client');
+      i++;
     } else if (args[i] === '--color') {
-      if (!args[i + 1]) throw new Error('--color requires a value.');
-      color = args[++i];
+      color = requireFlagValue(args, i, '--color');
+      i++;
     } else if (args[i] === '--public') {
       isPublic = true;
     } else if (!args[i].startsWith('-')) {

--- a/src/commands/project-edit.ts
+++ b/src/commands/project-edit.ts
@@ -2,7 +2,7 @@ import { config } from '../config.js';
 import { put } from '../api.js';
 import { resolveClientId } from '../clients.js';
 import { resolveProjectId } from '../projects.js';
-import { parseOrExit } from '../utils.js';
+import { parseOrExit, requireFlagValue } from '../utils.js';
 
 interface Project {
   id: number;
@@ -25,13 +25,6 @@ const USAGE =
   'Usage: tgp project-edit <project> [-n "New Name"] [-c "Client Name"] [--color "#0b83d9"] [--public|--private]';
 const VALID_FLAGS = new Set(['-n', '--name', '-c', '--client', '--color', '--public', '--private']);
 
-function requireValue(args: string[], index: number, flagName: string): string {
-  if (index + 1 >= args.length) {
-    throw new Error(`${flagName} requires a value.`);
-  }
-  return args[index + 1];
-}
-
 export function parseArgs(args: string[]): ParsedArgs {
   const project = args[0];
   let name: string | null = null;
@@ -51,13 +44,13 @@ export function parseArgs(args: string[]): ParsedArgs {
     }
 
     if (args[i] === '-n' || args[i] === '--name') {
-      name = requireValue(args, i, '--name');
+      name = requireFlagValue(args, i, args[i]);
       i++;
     } else if (args[i] === '-c' || args[i] === '--client') {
-      client = requireValue(args, i, '--client');
+      client = requireFlagValue(args, i, args[i]);
       i++;
     } else if (args[i] === '--color') {
-      color = requireValue(args, i, '--color');
+      color = requireFlagValue(args, i, args[i]);
       i++;
     } else if (args[i] === '--public') {
       if (isPrivate === true) {

--- a/src/commands/project-edit.ts
+++ b/src/commands/project-edit.ts
@@ -47,7 +47,7 @@ export function parseArgs(args: string[]): ParsedArgs {
       name = requireFlagValue(args, i, args[i]);
       i++;
     } else if (args[i] === '-c' || args[i] === '--client') {
-      client = requireFlagValue(args, i, args[i]);
+      client = requireFlagValue(args, i, args[i], { allowEmpty: true });
       i++;
     } else if (args[i] === '--color') {
       color = requireFlagValue(args, i, args[i]);

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -1,6 +1,13 @@
 import { config } from '../config.js';
 import { get, post } from '../api.js';
-import { parseDuration, buildStartTime, parseOrExit, localYesterdayDate, formatDate } from '../utils.js';
+import {
+  parseDuration,
+  buildStartTime,
+  parseOrExit,
+  localYesterdayDate,
+  formatDate,
+  requireFlagValue,
+} from '../utils.js';
 
 function isValidCalendarDate(s: string): boolean {
   const match = s.match(/^(\d{4})-(\d{2})-(\d{2})$/);
@@ -52,19 +59,23 @@ export function parseArgs(args: string[]): {
       );
     }
 
-    if ((args[i] === '-p' || args[i] === '--project') && args[i + 1]) {
-      project = args[++i];
-    } else if ((args[i] === '-t' || args[i] === '--tags') && args[i + 1]) {
-      tags = args[++i].split(',').map((t) => t.trim());
-    } else if (args[i] === '--at' && args[i + 1]) {
-      at = args[++i];
-    } else if (args[i] === '--dur' && args[i + 1]) {
-      dur = args[++i];
+    if (args[i] === '-p' || args[i] === '--project') {
+      project = requireFlagValue(args, i, args[i]);
+      i++;
+    } else if (args[i] === '-t' || args[i] === '--tags') {
+      tags = requireFlagValue(args, i, args[i])
+        .split(',')
+        .map((t) => t.trim());
+      i++;
+    } else if (args[i] === '--at') {
+      at = requireFlagValue(args, i, args[i]);
+      i++;
+    } else if (args[i] === '--dur') {
+      dur = requireFlagValue(args, i, args[i]);
+      i++;
     } else if (args[i] === '-d' || args[i] === '--date') {
-      if (!args[i + 1] || args[i + 1].startsWith('-')) {
-        throw new Error(`Missing value for ${args[i]}. Use YYYY-MM-DD or "yesterday".`);
-      }
-      date = args[++i];
+      date = requireFlagValue(args, i, args[i], 'Use YYYY-MM-DD or "yesterday".');
+      i++;
     } else if (!args[i].startsWith('-')) {
       description = args[i];
     }

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -74,7 +74,7 @@ export function parseArgs(args: string[]): {
       dur = requireFlagValue(args, i, args[i]);
       i++;
     } else if (args[i] === '-d' || args[i] === '--date') {
-      date = requireFlagValue(args, i, args[i], 'Use YYYY-MM-DD or "yesterday".');
+      date = requireFlagValue(args, i, args[i], { hint: 'Use YYYY-MM-DD or "yesterday".' });
       i++;
     } else if (!args[i].startsWith('-')) {
       description = args[i];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,10 +56,20 @@ export function localYesterdayDate(): Date {
   return d;
 }
 
+export function requireFlagValue(args: string[], index: number, flagName: string, hint?: string): string {
+  const val = args[index + 1];
+  if (val === undefined || (val !== '' && val.startsWith('-'))) {
+    const suffix = hint ? ` ${hint}` : '';
+    throw new Error(`Missing value for ${flagName}.${suffix}`);
+  }
+  return val;
+}
+
 export function parseDateArg(args: string[]): Date {
   const idx = args.indexOf('-d') !== -1 ? args.indexOf('-d') : args.indexOf('--date');
-  if (idx !== -1 && args[idx + 1]) {
-    const val = args[idx + 1];
+  if (idx !== -1) {
+    const flag = args[idx];
+    const val = requireFlagValue(args, idx, flag, 'Use YYYY-MM-DD or "yesterday".');
     if (val === 'yesterday') return localYesterdayDate();
     const d = new Date(val + 'T12:00:00');
     if (!isNaN(d.getTime())) return d;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,11 +56,19 @@ export function localYesterdayDate(): Date {
   return d;
 }
 
-export function requireFlagValue(args: string[], index: number, flagName: string, hint?: string): string {
+export function requireFlagValue(
+  args: string[],
+  index: number,
+  flagName: string,
+  options: { hint?: string; allowEmpty?: boolean } = {}
+): string {
   const val = args[index + 1];
+  const hintSuffix = options.hint ? ` ${options.hint}` : '';
   if (val === undefined || (val !== '' && val.startsWith('-'))) {
-    const suffix = hint ? ` ${hint}` : '';
-    throw new Error(`Missing value for ${flagName}.${suffix}`);
+    throw new Error(`Missing value for ${flagName}.${hintSuffix}`);
+  }
+  if (val === '' && !options.allowEmpty) {
+    throw new Error(`Missing value for ${flagName}.${hintSuffix}`);
   }
   return val;
 }
@@ -69,7 +77,7 @@ export function parseDateArg(args: string[]): Date {
   const idx = args.indexOf('-d') !== -1 ? args.indexOf('-d') : args.indexOf('--date');
   if (idx !== -1) {
     const flag = args[idx];
-    const val = requireFlagValue(args, idx, flag, 'Use YYYY-MM-DD or "yesterday".');
+    const val = requireFlagValue(args, idx, flag, { hint: 'Use YYYY-MM-DD or "yesterday".' });
     if (val === 'yesterday') return localYesterdayDate();
     const d = new Date(val + 'T12:00:00');
     if (!isNaN(d.getTime())) return d;

--- a/tests/entry-edit-parseArgs.test.ts
+++ b/tests/entry-edit-parseArgs.test.ts
@@ -112,4 +112,16 @@ describe('entry-edit parseArgs', () => {
   it('throws on --dur followed by another flag', () => {
     expect(() => parseArgs(['12345', '--dur', '-d', 'desc'])).toThrow('Missing value for --dur.');
   });
+
+  it('throws on -d with empty value', () => {
+    expect(() => parseArgs(['12345', '-d', ''])).toThrow('Missing value for -d.');
+  });
+
+  it('throws on -p with empty value', () => {
+    expect(() => parseArgs(['12345', '-p', ''])).toThrow('Missing value for -p.');
+  });
+
+  it('throws on --dur with empty value', () => {
+    expect(() => parseArgs(['12345', '--dur', ''])).toThrow('Missing value for --dur.');
+  });
 });

--- a/tests/entry-edit-parseArgs.test.ts
+++ b/tests/entry-edit-parseArgs.test.ts
@@ -76,4 +76,40 @@ describe('entry-edit parseArgs', () => {
     expect(result.description).toBe('Desc');
     expect(result.dur).toBe('45m');
   });
+
+  it('throws on -d with no value', () => {
+    expect(() => parseArgs(['12345', '-d'])).toThrow('Missing value for -d.');
+  });
+
+  it('throws on --description with no value', () => {
+    expect(() => parseArgs(['12345', '--description'])).toThrow('Missing value for --description.');
+  });
+
+  it('throws on -p with no value', () => {
+    expect(() => parseArgs(['12345', '-p'])).toThrow('Missing value for -p.');
+  });
+
+  it('throws on --project with no value', () => {
+    expect(() => parseArgs(['12345', '--project'])).toThrow('Missing value for --project.');
+  });
+
+  it('throws on --tags with no value', () => {
+    expect(() => parseArgs(['12345', '--tags'])).toThrow('Missing value for --tags.');
+  });
+
+  it('throws on --dur with no value', () => {
+    expect(() => parseArgs(['12345', '--dur'])).toThrow('Missing value for --dur.');
+  });
+
+  it('throws on -p followed by another flag', () => {
+    expect(() => parseArgs(['12345', '-p', '-t', 'foo'])).toThrow('Missing value for -p.');
+  });
+
+  it('throws on -d followed by -p', () => {
+    expect(() => parseArgs(['12345', '-d', '-p', 'X'])).toThrow('Missing value for -d.');
+  });
+
+  it('throws on --dur followed by another flag', () => {
+    expect(() => parseArgs(['12345', '--dur', '-d', 'desc'])).toThrow('Missing value for --dur.');
+  });
 });

--- a/tests/project-create.test.ts
+++ b/tests/project-create.test.ts
@@ -274,4 +274,32 @@ describe('projectCreate command', () => {
     exitSpy.mockRestore();
     errorSpy.mockRestore();
   });
+
+  it('exits when --color value is empty', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectCreate(['Project', '--color', ''])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --color.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when -c value is empty', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectCreate(['Project', '-c', ''])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for -c.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
 });

--- a/tests/project-create.test.ts
+++ b/tests/project-create.test.ts
@@ -227,7 +227,7 @@ describe('projectCreate command', () => {
 
     await expect(projectCreate(['Project', '--color'])).rejects.toThrow('exit');
 
-    expect(errorSpy).toHaveBeenCalledWith('--color requires a value.');
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --color.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     errorSpy.mockRestore();
@@ -241,7 +241,35 @@ describe('projectCreate command', () => {
 
     await expect(projectCreate(['Project', '-c'])).rejects.toThrow('exit');
 
-    expect(errorSpy).toHaveBeenCalledWith('--client requires a value.');
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for -c.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when --color is followed by another flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectCreate(['Project', '--color', '--public'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --color.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when -c is followed by another flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectCreate(['Project', '-c', '--color', 'red'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for -c.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     errorSpy.mockRestore();

--- a/tests/project-edit.test.ts
+++ b/tests/project-edit.test.ts
@@ -86,7 +86,49 @@ describe('projectEdit command', () => {
 
     await expect(projectEdit(['456', '--color'])).rejects.toThrow('exit');
 
-    expect(errorSpy).toHaveBeenCalledWith('--color requires a value.');
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --color.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when flag value is another flag (--color --name)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '--color', '--name', 'foo'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --color.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when -n is followed by another flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '-n', '--public'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for -n.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when --client is followed by another flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '--client', '--color', 'red'])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --client.');
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
     errorSpy.mockRestore();

--- a/tests/project-edit.test.ts
+++ b/tests/project-edit.test.ts
@@ -134,6 +134,34 @@ describe('projectEdit command', () => {
     errorSpy.mockRestore();
   });
 
+  it('exits when --name value is empty', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '-n', ''])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for -n.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits when --color value is empty', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(projectEdit(['456', '--color', ''])).rejects.toThrow('exit');
+
+    expect(errorSpy).toHaveBeenCalledWith('Missing value for --color.');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
   it('exits when no edit flags are provided', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('exit');

--- a/tests/track-parseArgs.test.ts
+++ b/tests/track-parseArgs.test.ts
@@ -120,4 +120,40 @@ describe('track parseArgs', () => {
   it('throws on empty args', () => {
     expect(() => parseArgs([])).toThrow('Usage');
   });
+
+  it('throws on -p with no value', () => {
+    expect(() => parseArgs(['Work', '-p'])).toThrow('Missing value for -p.');
+  });
+
+  it('throws on --project with no value', () => {
+    expect(() => parseArgs(['Work', '--project'])).toThrow('Missing value for --project.');
+  });
+
+  it('throws on -t with no value', () => {
+    expect(() => parseArgs(['Work', '-t'])).toThrow('Missing value for -t.');
+  });
+
+  it('throws on --tags with no value', () => {
+    expect(() => parseArgs(['Work', '--tags'])).toThrow('Missing value for --tags.');
+  });
+
+  it('throws on --at with no value', () => {
+    expect(() => parseArgs(['Work', '--at'])).toThrow('Missing value for --at.');
+  });
+
+  it('throws on --dur with no value', () => {
+    expect(() => parseArgs(['Work', '--dur'])).toThrow('Missing value for --dur.');
+  });
+
+  it('throws on -p followed by another flag', () => {
+    expect(() => parseArgs(['Work', '-p', '-t', 'foo'])).toThrow('Missing value for -p.');
+  });
+
+  it('throws on --at followed by --dur (issue example)', () => {
+    expect(() => parseArgs(['Work', '--at', '--dur', '30m'])).toThrow('Missing value for --at.');
+  });
+
+  it('throws on --dur followed by another flag', () => {
+    expect(() => parseArgs(['Work', '--at', '09:00', '--dur', '--at'])).toThrow('Missing value for --dur.');
+  });
 });

--- a/tests/track-parseArgs.test.ts
+++ b/tests/track-parseArgs.test.ts
@@ -156,4 +156,20 @@ describe('track parseArgs', () => {
   it('throws on --dur followed by another flag', () => {
     expect(() => parseArgs(['Work', '--at', '09:00', '--dur', '--at'])).toThrow('Missing value for --dur.');
   });
+
+  it('throws on --dur with empty value (would create running timer with timed path)', () => {
+    expect(() => parseArgs(['Work', '--at', '09:00', '--dur', ''])).toThrow('Missing value for --dur.');
+  });
+
+  it('throws on --at with empty value', () => {
+    expect(() => parseArgs(['Work', '--at', '', '--dur', '30m'])).toThrow('Missing value for --at.');
+  });
+
+  it('throws on -p with empty value', () => {
+    expect(() => parseArgs(['Work', '-p', ''])).toThrow('Missing value for -p.');
+  });
+
+  it('throws on -t with empty value', () => {
+    expect(() => parseArgs(['Work', '-t', ''])).toThrow('Missing value for -t.');
+  });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -264,12 +264,28 @@ describe('requireFlagValue', () => {
     expect(() => requireFlagValue(['-p', '--dur', '30m'], 0, '-p')).toThrow('Missing value for -p.');
   });
 
-  it('returns an empty string when the value is empty', () => {
-    expect(requireFlagValue(['--client', ''], 0, '--client')).toBe('');
+  it('throws on empty string by default', () => {
+    expect(() => requireFlagValue(['-p', ''], 0, '-p')).toThrow('Missing value for -p.');
   });
 
-  it('includes a hint when provided', () => {
-    expect(() => requireFlagValue(['-d'], 0, '-d', 'Use YYYY-MM-DD or "yesterday".')).toThrow(
+  it('returns an empty string when allowEmpty is true', () => {
+    expect(requireFlagValue(['--client', ''], 0, '--client', { allowEmpty: true })).toBe('');
+  });
+
+  it('still rejects the next arg starting with - even when allowEmpty is true', () => {
+    expect(() => requireFlagValue(['--client', '--name', 'X'], 0, '--client', { allowEmpty: true })).toThrow(
+      'Missing value for --client.'
+    );
+  });
+
+  it('includes a hint in the error message', () => {
+    expect(() => requireFlagValue(['-d'], 0, '-d', { hint: 'Use YYYY-MM-DD or "yesterday".' })).toThrow(
+      'Missing value for -d. Use YYYY-MM-DD or "yesterday".'
+    );
+  });
+
+  it('includes a hint even when allowEmpty is true and value is empty', () => {
+    expect(() => requireFlagValue(['-d', ''], 0, '-d', { hint: 'Use YYYY-MM-DD or "yesterday".' })).toThrow(
       'Missing value for -d. Use YYYY-MM-DD or "yesterday".'
     );
   });
@@ -290,5 +306,9 @@ describe('parseDateArg missing-value behavior', () => {
 
   it('throws when --date is followed by another flag', () => {
     expect(() => parseDateArg(['--date', '-v'])).toThrow('Missing value for --date');
+  });
+
+  it('throws when -d value is empty', () => {
+    expect(() => parseDateArg(['-d', ''])).toThrow('Missing value for -d');
   });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
   parseDateArg,
   parseOrExit,
   localYesterdayDate,
+  requireFlagValue,
 } from '../src/utils.js';
 
 describe('formatDuration', () => {
@@ -247,5 +248,47 @@ describe('parseOrExit', () => {
 
     errorSpy.mockRestore();
     exitSpy.mockRestore();
+  });
+});
+
+describe('requireFlagValue', () => {
+  it('returns the next arg when present and not a flag', () => {
+    expect(requireFlagValue(['-p', 'Dev-Pilot'], 0, '-p')).toBe('Dev-Pilot');
+  });
+
+  it('throws when the flag is the last arg', () => {
+    expect(() => requireFlagValue(['-p'], 0, '-p')).toThrow('Missing value for -p.');
+  });
+
+  it('throws when the next arg starts with -', () => {
+    expect(() => requireFlagValue(['-p', '--dur', '30m'], 0, '-p')).toThrow('Missing value for -p.');
+  });
+
+  it('returns an empty string when the value is empty', () => {
+    expect(requireFlagValue(['--client', ''], 0, '--client')).toBe('');
+  });
+
+  it('includes a hint when provided', () => {
+    expect(() => requireFlagValue(['-d'], 0, '-d', 'Use YYYY-MM-DD or "yesterday".')).toThrow(
+      'Missing value for -d. Use YYYY-MM-DD or "yesterday".'
+    );
+  });
+});
+
+describe('parseDateArg missing-value behavior', () => {
+  it('throws when -d is the last arg', () => {
+    expect(() => parseDateArg(['-d'])).toThrow('Missing value for -d');
+  });
+
+  it('throws when -d is followed by another flag', () => {
+    expect(() => parseDateArg(['-d', '--foo'])).toThrow('Missing value for -d');
+  });
+
+  it('throws when --date is the last arg', () => {
+    expect(() => parseDateArg(['--date'])).toThrow('Missing value for --date');
+  });
+
+  it('throws when --date is followed by another flag', () => {
+    expect(() => parseDateArg(['--date', '-v'])).toThrow('Missing value for --date');
   });
 });


### PR DESCRIPTION
Closes #150.

## Problem

Several commands used `if (args[i + 1])` to check whether a flag's value was present, which silently dropped the flag when the value was missing or when the next token was itself another flag. For example:

```bash
tgp track "Work" -p              # -p silently dropped, no project
tgp track "Work" --at --dur 30m   # --at dropped, --dur errors alone
```

project-create and project-edit already threw on missing values, but did not guard against the next arg being another flag (e.g. `--color --name foo` would consume --name as the color).

## Fix

Introduce a shared `requireFlagValue` helper in `utils.ts` with the signature:

```ts
requireFlagValue(args, index, flagName, { hint?, allowEmpty? })
```

It throws `Missing value for -p.` (with optional hint) when the value is:
- undefined (flag is the last arg)
- a non-empty string starting with `-` (next token is another flag)
- an empty string, unless the call site opts in via `allowEmpty: true`

Empty string is permitted only for the two known intentional clear/unset cases:
- `entry-edit -t/--tags ''` clears all tags
- `project-edit -c/--client ''` unsets the client

All other flags (track -p/-t/--at/--dur/-d, entry-edit -d/-p/--dur, project-create -c/--color, project-edit -n/--color, parseDateArg -d) now reject empty input. Notably, this prevents `tgp track Work --at 09:00 --dur ''` from silently creating a running timer under the "Logged" message.

Wired into: `track`, `entry-edit`, `project-create`, `project-edit`, and the `parseDateArg` utility (used by `entry-list` and `week`).

## Verification

- 295 tests pass (50 new tests covering missing-value, '-X' as value, and empty-string rejection paths)
- `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm run lint:md` all clean