### PR TITLE
feat: add tgp resume command (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Run `tgp` without arguments to see all available commands.
 | `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
 | `tgp track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
 | `tgp stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
+| `tgp resume`                            | Resume last stopped timer   | [docs/resume.md](docs/resume.md)             |
 | `tgp entry-edit <id> -d/-p/-t/--dur`    | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
 | `tgp week`                              | Weekly summary by project   | [docs/week.md](docs/week.md)                 |
 | `tgp entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -1,0 +1,41 @@
+# `resume` - Resume Last Stopped Timer
+
+Starts a new running timer using the most recent stopped entry from today.
+
+## Usage
+
+```bash
+tgp resume
+```
+
+## Behavior
+
+`resume` fetches recent time entries from Toggl and finds the latest stopped entry
+whose stop time is today in your local calendar. It starts a new timer with the
+same description, project, tags, and workspace.
+
+If a timer is already running, `resume` prints an error and does not start a new
+one. Stop the running timer with `tgp stop` first.
+
+Entries from previous days are ignored, even if they are the most recent stopped
+entries overall. Running entries are ignored.
+
+## Output
+
+With a stopped task today:
+
+```text
+Started: Fixing login bug [Dev-Pilot] {dev, bug} (id: 4383678598)
+```
+
+Without a stopped task today:
+
+```text
+No stopped task found today to resume.
+```
+
+With a timer already running:
+
+```text
+Timer "Fixing login bug" is already running. Stop it first with 'tgp stop'.
+```

--- a/src/commands/entry-list.ts
+++ b/src/commands/entry-list.ts
@@ -1,18 +1,7 @@
 import { config } from '../config.js';
 import { get } from '../api.js';
+import type { TimeEntry } from '../types.js';
 import { formatDate, formatTime, formatDuration, parseDateArg, parseOrExit, DASH } from '../utils.js';
-
-interface TimeEntry {
-  id: number;
-  description: string;
-  start: string;
-  stop: string | null;
-  duration: number;
-  project_id: number | null;
-  project_name: string | null;
-  tags: string[] | null;
-  workspace_id: number;
-}
 
 export async function entryList(args: string[]) {
   const date = parseOrExit(() => parseDateArg(args));

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -1,0 +1,62 @@
+import { get, post } from '../api.js';
+import type { TimeEntry } from '../types.js';
+import { formatDate } from '../utils.js';
+
+function isStoppedToday(entry: TimeEntry, today: Date): boolean {
+  if (entry.stop === null || entry.duration < 0) return false;
+  return formatDate(new Date(entry.stop)) === formatDate(today);
+}
+
+export function findLatestStoppedToday(entries: TimeEntry[], today: Date): TimeEntry | null {
+  const stoppedToday = entries.filter((entry) => isStoppedToday(entry, today));
+  if (stoppedToday.length === 0) return null;
+
+  stoppedToday.sort((a, b) => new Date(b.stop!).getTime() - new Date(a.stop!).getTime());
+  return stoppedToday[0];
+}
+
+function getResumeWindow(today: Date): { startDate: string; endDate: string } {
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+  return {
+    startDate: formatDate(yesterday),
+    endDate: formatDate(tomorrow),
+  };
+}
+
+export async function resume() {
+  const current = await get<TimeEntry | null>('/me/time_entries/current');
+  if (current) {
+    console.error(
+      `Timer "${current.description || '(no description)'}" is already running. Stop it first with 'tgp stop'.`
+    );
+    return;
+  }
+
+  const today = new Date();
+  const { startDate, endDate } = getResumeWindow(today);
+  const timeEntries = await get<TimeEntry[]>(`/me/time_entries?start_date=${startDate}&end_date=${endDate}`);
+  const lastStopped = findLatestStoppedToday(timeEntries, today);
+
+  if (!lastStopped) {
+    console.error('No stopped task found today to resume.');
+    return;
+  }
+
+  const entry = await post<TimeEntry>(`/workspaces/${lastStopped.workspace_id}/time_entries`, {
+    description: lastStopped.description,
+    project_id: lastStopped.project_id,
+    tags: lastStopped.tags && lastStopped.tags.length > 0 ? lastStopped.tags : undefined,
+    start: new Date().toISOString(),
+    duration: -1,
+    workspace_id: lastStopped.workspace_id,
+    created_with: 'toggl-pilot',
+  });
+
+  const description = entry.description || '(no description)';
+  const projectLabel = entry.project_name ? ` [${entry.project_name}]` : '';
+  const tagLabel = entry.tags?.length ? ` {${entry.tags.join(', ')}}` : '';
+  console.log(`Started: ${description}${projectLabel}${tagLabel} (id: ${entry.id})`);
+}

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,15 +1,6 @@
 import { get, put } from '../api.js';
+import type { TimeEntry } from '../types.js';
 import { formatDuration } from '../utils.js';
-
-interface TimeEntry {
-  id: number;
-  description: string;
-  start: string;
-  stop: string | null;
-  duration: number;
-  project_name: string | null;
-  workspace_id: number;
-}
 
 export async function stop() {
   const current = await get<TimeEntry | null>('/me/time_entries/current');

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -1,5 +1,6 @@
 import { config } from '../config.js';
 import { get, post } from '../api.js';
+import type { TimeEntry } from '../types.js';
 import {
   parseDuration,
   buildStartTime,
@@ -22,17 +23,6 @@ function isValidCalendarDate(s: string): boolean {
 interface Project {
   id: number;
   name: string;
-}
-
-interface TimeEntry {
-  id: number;
-  description: string;
-  start: string;
-  duration: number;
-  project_id: number | null;
-  project_name: string | null;
-  tags: string[] | null;
-  workspace_id: number;
 }
 
 const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '--at', '--dur', '-d', '--date']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { workspaceList } from './commands/workspace-list.js';
 import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
 import { stop } from './commands/stop.js';
+import { resume } from './commands/resume.js';
 import { tagList } from './commands/tag-list.js';
 import { tagCreate } from './commands/tag-create.js';
 import { tagRename } from './commands/tag-rename.js';
@@ -75,6 +76,9 @@ if (command === 'auth') {
     case 'stop':
       stop();
       break;
+    case 'resume':
+      resume();
+      break;
     case 'tag-list':
       tagList();
       break;
@@ -113,7 +117,9 @@ if (command === 'auth') {
       console.error('Commands:');
       console.error('  auth             version          me');
       console.error('  workspace-list');
-      console.error('  track            stop             entry-edit       entry-list       entry-delete');
+      console.error(
+        '  track            stop             resume           entry-edit       entry-list       entry-delete'
+      );
       console.error('  week');
       console.error('  client-list');
       console.error('  project-list     project-create   project-edit     project-rename   project-archive');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+export interface TimeEntry {
+  id: number;
+  description: string;
+  start: string;
+  stop: string | null;
+  duration: number;
+  project_id: number | null;
+  project_name: string | null;
+  tags: string[] | null;
+  workspace_id: number;
+}

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+import { get, post } from '../src/api.js';
+import { resume } from '../src/commands/resume.js';
+
+const mockedGet = vi.mocked(get);
+const mockedPost = vi.mocked(post);
+
+const today = '2025-06-15T12:00:00';
+
+interface TimeEntry {
+  id: number;
+  description: string;
+  start: string;
+  stop: string | null;
+  duration: number;
+  project_id: number | null;
+  project_name: string | null;
+  tags: string[] | null;
+  workspace_id: number;
+}
+
+function toUtcIso(dateTime: string): string {
+  return new Date(dateTime).toISOString();
+}
+
+function makeEntry(overrides: Partial<TimeEntry> = {}): TimeEntry {
+  return {
+    id: 100,
+    description: 'Working on feature',
+    start: toUtcIso('2025-06-15T09:00:00'),
+    stop: toUtcIso('2025-06-15T10:00:00'),
+    duration: 3600,
+    project_id: 10,
+    project_name: 'Dev-Pilot',
+    tags: ['dev', 'bug'],
+    workspace_id: 123,
+    ...overrides,
+  };
+}
+
+describe('resume command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(today));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('resumes the latest stopped entry from today', async () => {
+    const stoppedEntry = makeEntry();
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
+    mockedPost.mockResolvedValue({
+      ...stoppedEntry,
+      id: 999,
+      start: toUtcIso('2025-06-15T12:00:00'),
+      stop: null,
+      duration: -1,
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await resume();
+
+    expect(mockedGet).toHaveBeenNthCalledWith(1, '/me/time_entries/current');
+    expect(mockedGet).toHaveBeenNthCalledWith(
+      2,
+      '/me/time_entries?start_date=2025-06-14&end_date=2025-06-16'
+    );
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({
+        description: 'Working on feature',
+        project_id: 10,
+        tags: ['dev', 'bug'],
+        start: new Date(today).toISOString(),
+        duration: -1,
+        workspace_id: 123,
+        created_with: 'toggl-pilot',
+      })
+    );
+    expect(logSpy).toHaveBeenCalledWith('Started: Working on feature [Dev-Pilot] {dev, bug} (id: 999)');
+  });
+
+  it('ignores running entries', async () => {
+    const runningEntry = makeEntry({
+      id: 101,
+      description: 'Running task',
+      stop: null,
+      duration: -1,
+    });
+    const stoppedEntry = makeEntry({ id: 102, description: 'Stopped task' });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([runningEntry, stoppedEntry]);
+    mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
+
+    await resume();
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({ description: 'Stopped task' })
+    );
+  });
+
+  it('ignores entries stopped on the previous local day', async () => {
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([
+      makeEntry({
+        id: 101,
+        description: 'Yesterday',
+        stop: toUtcIso('2025-06-14T23:59:00'),
+      }),
+    ]);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await resume();
+
+    expect(errorSpy).toHaveBeenCalledWith('No stopped task found today to resume.');
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('chooses the latest entry by stop time', async () => {
+    const earlyEntry = makeEntry({
+      id: 101,
+      description: 'Early',
+      stop: toUtcIso('2025-06-15T10:00:00'),
+    });
+    const lateEntry = makeEntry({
+      id: 102,
+      description: 'Late',
+      stop: toUtcIso('2025-06-15T11:00:00'),
+    });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([lateEntry, earlyEntry]);
+    mockedPost.mockResolvedValue({ ...lateEntry, id: 999, stop: null, duration: -1 });
+
+    await resume();
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({ description: 'Late' })
+    );
+  });
+
+  it('preserves description, project, tags, and workspace', async () => {
+    const stoppedEntry = makeEntry({
+      description: 'Review PR',
+      project_id: 456,
+      tags: ['review', 'client'],
+      workspace_id: 789,
+    });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
+    mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
+
+    await resume();
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/789/time_entries',
+      expect.objectContaining({
+        description: 'Review PR',
+        project_id: 456,
+        tags: ['review', 'client'],
+        workspace_id: 789,
+      })
+    );
+  });
+
+  it('omits null tags from the post payload', async () => {
+    const stoppedEntry = makeEntry({ tags: null });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
+    mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
+
+    await resume();
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.not.objectContaining({ tags: expect.anything() })
+    );
+  });
+
+  it('omits empty tags from the post payload', async () => {
+    const stoppedEntry = makeEntry({ tags: [] });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
+    mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
+
+    await resume();
+
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.not.objectContaining({ tags: expect.anything() })
+    );
+  });
+
+  it('prints an error and does not post when no stopped task exists today', async () => {
+    mockedGet
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce([
+        makeEntry({ stop: null, duration: -1 }),
+        makeEntry({ stop: toUtcIso('2025-06-14T18:00:00') }),
+      ]);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await resume();
+
+    expect(errorSpy).toHaveBeenCalledWith('No stopped task found today to resume.');
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('prints an error and does not post when a timer is already running', async () => {
+    mockedGet.mockResolvedValueOnce(
+      makeEntry({
+        description: 'Current task',
+        stop: null,
+        duration: -1,
+      })
+    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await resume();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Timer "Current task" is already running. Stop it first with 'tgp stop'.`
+    );
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('prints fallback text for an empty resumed description', async () => {
+    const stoppedEntry = makeEntry({ description: '' });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
+    mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await resume();
+
+    expect(logSpy).toHaveBeenCalledWith('Started: (no description) [Dev-Pilot] {dev, bug} (id: 999)');
+  });
+});


### PR DESCRIPTION
Adds `tgp resume`, which starts a new running timer using the most recent stopped entry from today (local calendar). Description, project, tags, and workspace are preserved.

- Errors out with a helpful message if a timer is already running (mirrors `tgp stop`'s check of `/me/time_entries/current`).
- Errors out with a clear message if no stopped task exists today.
- 3-day query window (`yesterday`–`tomorrow`) for timezone safety across the local/UTC date boundary.
- Extracted `TimeEntry` to `src/types.ts`; updated existing call sites that had duplicate copies.

Tests: 10 new unit tests in `tests/resume.test.ts`. Full command docs in `docs/resume.md`.

Closes #140
