### PR TITLE
feat: add client-add command (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Run `tgp` without arguments to see all available commands.
 
 ### Clients
 
-| Command           | Description            | Docs                                       |
-| ----------------- | ---------------------- | ------------------------------------------ |
-| `tgp client-list` | List workspace clients | [docs/client-list.md](docs/client-list.md) |
+| Command                               | Description            | Docs                                       |
+| ------------------------------------- | ---------------------- | ------------------------------------------ |
+| `tgp client-list`                     | List workspace clients | [docs/client-list.md](docs/client-list.md) |
+| `tgp client-add "Name" [--notes "x"]` | Create a client        | [docs/client-add.md](docs/client-add.md)   |
 
 ### Projects
 

--- a/docs/client-add.md
+++ b/docs/client-add.md
@@ -1,0 +1,34 @@
+# `client-add` — Create a Client
+
+Creates a new client in your workspace.
+
+## Usage
+
+```bash
+tgp client-add "Client Name" [--notes "Some notes"]
+```
+
+## Output
+
+```text
+Created: Acme Corp (id: 123456789)
+```
+
+## Arguments
+
+| Argument        | Description             |
+| --------------- | ----------------------- |
+| `"Client Name"` | Name for the new client |
+
+## Flags
+
+| Flag             | Description                   |
+| ---------------- | ----------------------------- |
+| `--notes <text>` | Optional notes for the client |
+
+## Examples
+
+```bash
+tgp client-add "Acme Corp"
+tgp client-add "Acme Corp" --notes "Primary billing contact"
+```

--- a/src/commands/client-add.ts
+++ b/src/commands/client-add.ts
@@ -1,0 +1,59 @@
+import { config } from '../config.js';
+import { post } from '../api.js';
+import { parseOrExit, requireFlagValue } from '../utils.js';
+
+interface Client {
+  id: number;
+  name: string;
+  notes?: string | null;
+  wid: number;
+}
+
+const USAGE = 'Usage: tgp client-add "Client Name" [--notes "Some notes"]';
+const VALID_FLAGS = new Set(['--notes']);
+
+function parseArgs(args: string[]) {
+  let name = '';
+  let notes: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('-') && !VALID_FLAGS.has(args[i])) {
+      throw new Error(`Unknown flag: ${args[i]}. Valid flag: --notes`);
+    }
+
+    if (args[i] === '--notes') {
+      notes = requireFlagValue(args, i, '--notes');
+      i++;
+    } else if (!args[i].startsWith('-')) {
+      name = args[i];
+    }
+  }
+
+  if (!name) {
+    throw new Error(USAGE);
+  }
+
+  return { name, notes };
+}
+
+export async function clientAdd(args: string[]) {
+  const { name, notes } = parseOrExit(() => parseArgs(args));
+  const wsId = await config.getWorkspaceId();
+
+  const body: Record<string, unknown> = { name };
+  if (notes) {
+    body.notes = notes;
+  }
+
+  try {
+    const client = await post<Client>(`/workspaces/${wsId}/clients`, body);
+    console.log(`Created: ${client.name} (id: ${client.id})`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('400')) {
+      console.error(`Client "${name}" could not be created. Check for duplicates or invalid parameters.`);
+      return;
+    }
+    throw e;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { entryList } from './commands/entry-list.js';
 import { week } from './commands/week.js';
 import { projectList } from './commands/project-list.js';
 import { clientList } from './commands/client-list.js';
+import { clientAdd } from './commands/client-add.js';
 import { workspaceList } from './commands/workspace-list.js';
 import { entryDelete } from './commands/entry-delete.js';
 import { track } from './commands/track.js';
@@ -64,6 +65,9 @@ if (command === 'auth') {
     case 'client-list':
       clientList(args);
       break;
+    case 'client-add':
+      clientAdd(args);
+      break;
     case 'workspace-list':
       workspaceList();
       break;
@@ -121,7 +125,7 @@ if (command === 'auth') {
         '  track            stop             resume           entry-edit       entry-list       entry-delete'
       );
       console.error('  week');
-      console.error('  client-list');
+      console.error('  client-list      client-add');
       console.error('  project-list     project-create   project-edit     project-rename   project-archive');
       console.error('  project-restore  project-delete');
       console.error('  tag-list         tag-create       tag-rename       tag-delete');

--- a/tests/client-add.test.ts
+++ b/tests/client-add.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/api.js', () => ({
+  post: vi.fn(),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    getWorkspaceId: vi.fn().mockResolvedValue(123),
+  },
+}));
+
+import { post } from '../src/api.js';
+import { clientAdd } from '../src/commands/client-add.js';
+
+const mockedPost = vi.mocked(post);
+
+describe('clientAdd command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exits with usage message when no name provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(clientAdd([])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Usage: tgp client-add "Client Name" [--notes "Some notes"]');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('exits on unknown flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(clientAdd(['Acme', '--bogus'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Unknown flag: --bogus. Valid flag: --notes');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('creates client and prints confirmation', async () => {
+    mockedPost.mockResolvedValue({ id: 123456789, name: 'Acme Corp' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientAdd(['Acme Corp']);
+
+    expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/clients', {
+      name: 'Acme Corp',
+    });
+    expect(logSpy).toHaveBeenCalledWith('Created: Acme Corp (id: 123456789)');
+    logSpy.mockRestore();
+  });
+
+  it('passes --notes to body when provided', async () => {
+    mockedPost.mockResolvedValue({ id: 1, name: 'Acme Corp' });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await clientAdd(['Acme Corp', '--notes', 'Some notes']);
+
+    expect(mockedPost).toHaveBeenCalledWith('/workspaces/123/clients', {
+      name: 'Acme Corp',
+      notes: 'Some notes',
+    });
+    logSpy.mockRestore();
+  });
+
+  it('handles 400 error (duplicate/invalid name)', async () => {
+    mockedPost.mockRejectedValue(new Error('Toggl API 400: Bad Request'));
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await clientAdd(['Acme Corp']);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'Client "Acme Corp" could not be created. Check for duplicates or invalid parameters.'
+    );
+    logSpy.mockRestore();
+  });
+
+  it('re-throws non-400 errors', async () => {
+    mockedPost.mockRejectedValue(new Error('Toggl API 500: Server Error'));
+
+    await expect(clientAdd(['Acme Corp'])).rejects.toThrow('500');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `client-add` command to create a new Toggl Track client in the active workspace, completing the Clients group started by `client-list`.

Closes #27.

## Usage

```bash
tgp client-add "Client Name" [--notes "Some notes"]
```

## Output

```text
Created: Acme Corp (id: 123456789)
```

## Implementation

- `POST /workspaces/{workspace_id}/clients` with body `{ name }` (+ optional `notes`)
- Modeled on `project-create.ts`: `parseArgs` + `parseOrExit` + `requireFlagValue` + a `VALID_FLAGS` set
- Friendly message on `400` (duplicate/invalid); re-throws other API errors
- Wired into the dispatcher and help block in `src/index.ts`
- Added `tests/client-add.test.ts` (6 tests) and `docs/client-add.md`

## Design note

Issue #27's body table lists only `name` (+ optional `notes`), so the body does **not** include `wid`/`workspace_id` — the workspace is taken from the URL path. (Differs from `tag-create`, which sends `workspace_id` in the body.) The first live API call confirms this.

## Verification

- `npm run typecheck`
- `npm test` — 311 passed
- `npm run lint`
- `npm run format:check`
- `npm run lint:md`