### PR TITLE
feat: allow tgp resume <id> to restart any task (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run `tgp` without arguments to see all available commands.
 | `tgp entry-list`                        | List time entries for a day | [docs/entry-list.md](docs/entry-list.md)     |
 | `tgp track "Desc" -p "Project" -t tags` | Start a timer or log time   | [docs/track.md](docs/track.md)               |
 | `tgp stop`                              | Stop running timer          | [docs/stop.md](docs/stop.md)                 |
-| `tgp resume`                            | Resume last stopped timer   | [docs/resume.md](docs/resume.md)             |
+| `tgp resume [<id>]`                     | Resume a stopped timer      | [docs/resume.md](docs/resume.md)             |
 | `tgp entry-edit <id> -d/-p/-t/--dur`    | Edit a time entry           | [docs/entry-edit.md](docs/entry-edit.md)     |
 | `tgp week`                              | Weekly summary by project   | [docs/week.md](docs/week.md)                 |
 | `tgp entry-delete <id>`                 | Delete a time entry         | [docs/entry-delete.md](docs/entry-delete.md) |

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -1,37 +1,64 @@
-# `resume` - Resume Last Stopped Timer
+# `resume` - Resume a Stopped Timer
 
-Starts a new running timer using the most recent stopped entry from today.
+Starts a new running timer from a previously stopped entry.
 
 ## Usage
 
 ```bash
-tgp resume
+tgp resume            # resume the latest task stopped today
+tgp resume <id>       # resume a specific entry by ID
 ```
+
+The `<id>` is the value shown in the first column of `tgp entry-list`, matching the
+convention used by `tgp entry-edit <id>` and `tgp entry-delete <id>`.
 
 ## Behavior
 
-`resume` fetches recent time entries from Toggl and finds the latest stopped entry
-whose stop time is today in your local calendar. It starts a new timer with the
-same description, project, tags, and workspace.
+### No argument (`tgp resume`)
 
-If a timer is already running, `resume` prints an error and does not start a new
-one. Stop the running timer with `tgp stop` first.
+Fetches recent time entries from Toggl and finds the latest stopped entry whose
+stop time is today in your local calendar. It starts a new timer with the same
+description, project, tags, and workspace.
 
 Entries from previous days are ignored, even if they are the most recent stopped
 entries overall. Running entries are ignored.
 
+### With an entry ID (`tgp resume <id>`)
+
+Fetches that single entry via `GET /me/time_entries/{id}` and starts a new timer
+with the same description, project, tags, and workspace. The "stopped today"
+restriction does **not** apply — this lets you reach back further than today's
+most recent stop.
+
+## Common behavior
+
+If a timer is already running, `resume` prints an error and does not start a new
+one. Stop the running timer with `tgp stop` first.
+
 ## Output
 
-With a stopped task today:
+Resuming a stopped task:
 
 ```text
 Started: Fixing login bug [Dev-Pilot] {dev, bug} (id: 4383678598)
 ```
 
-Without a stopped task today:
+No stopped task today (no-arg form):
 
 ```text
 No stopped task found today to resume.
+```
+
+Entry ID not found:
+
+```text
+Time entry 999999 not found.
+```
+
+Entry ID is still running:
+
+```text
+Time entry 4383678598 is still running and cannot be resumed. Stop it first with 'tgp stop'.
 ```
 
 With a timer already running:

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -26,15 +26,26 @@ function getResumeWindow(today: Date): { startDate: string; endDate: string } {
   };
 }
 
-export async function resume() {
-  const current = await get<TimeEntry | null>('/me/time_entries/current');
-  if (current) {
-    console.error(
-      `Timer "${current.description || '(no description)'}" is already running. Stop it first with 'tgp stop'.`
-    );
-    return;
-  }
+function startFrom(entry: TimeEntry): Promise<TimeEntry> {
+  return post<TimeEntry>(`/workspaces/${entry.workspace_id}/time_entries`, {
+    description: entry.description,
+    project_id: entry.project_id,
+    tags: entry.tags && entry.tags.length > 0 ? entry.tags : undefined,
+    start: new Date().toISOString(),
+    duration: -1,
+    workspace_id: entry.workspace_id,
+    created_with: 'toggl-pilot',
+  });
+}
 
+function printStarted(entry: TimeEntry): void {
+  const description = entry.description || '(no description)';
+  const projectLabel = entry.project_name ? ` [${entry.project_name}]` : '';
+  const tagLabel = entry.tags?.length ? ` {${entry.tags.join(', ')}}` : '';
+  console.log(`Started: ${description}${projectLabel}${tagLabel} (id: ${entry.id})`);
+}
+
+async function resumeLatest(): Promise<void> {
   const today = new Date();
   const { startDate, endDate } = getResumeWindow(today);
   const timeEntries = await get<TimeEntry[]>(`/me/time_entries?start_date=${startDate}&end_date=${endDate}`);
@@ -45,18 +56,52 @@ export async function resume() {
     return;
   }
 
-  const entry = await post<TimeEntry>(`/workspaces/${lastStopped.workspace_id}/time_entries`, {
-    description: lastStopped.description,
-    project_id: lastStopped.project_id,
-    tags: lastStopped.tags && lastStopped.tags.length > 0 ? lastStopped.tags : undefined,
-    start: new Date().toISOString(),
-    duration: -1,
-    workspace_id: lastStopped.workspace_id,
-    created_with: 'toggl-pilot',
-  });
+  const entry = await startFrom(lastStopped);
+  printStarted(entry);
+}
 
-  const description = entry.description || '(no description)';
-  const projectLabel = entry.project_name ? ` [${entry.project_name}]` : '';
-  const tagLabel = entry.tags?.length ? ` {${entry.tags.join(', ')}}` : '';
-  console.log(`Started: ${description}${projectLabel}${tagLabel} (id: ${entry.id})`);
+async function resumeById(rawId: string): Promise<void> {
+  let entry: TimeEntry;
+  try {
+    entry = await get<TimeEntry>(`/me/time_entries/${rawId}`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('400') || msg.includes('404')) {
+      console.error(`Time entry ${rawId} not found.`);
+      return;
+    }
+    throw e;
+  }
+
+  if (entry.duration < 0) {
+    console.error(
+      `Time entry ${rawId} is still running and cannot be resumed. Stop it first with 'tgp stop'.`
+    );
+    return;
+  }
+
+  const started = await startFrom(entry);
+  printStarted(started);
+}
+
+export async function resume(args: string[]) {
+  const positional = args.filter((a) => !a.startsWith('-'));
+  if (args.some((a) => a.startsWith('-')) || positional.length > 1) {
+    console.error('Usage: tgp resume [<entry_id>]');
+    process.exit(1);
+  }
+
+  const current = await get<TimeEntry | null>('/me/time_entries/current');
+  if (current) {
+    console.error(
+      `Timer "${current.description || '(no description)'}" is already running. Stop it first with 'tgp stop'.`
+    );
+    return;
+  }
+
+  if (positional.length === 1) {
+    await resumeById(positional[0]);
+  } else {
+    await resumeLatest();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ if (command === 'auth') {
       stop();
       break;
     case 'resume':
-      resume();
+      resume(args);
       break;
     case 'tag-list':
       tagList();
@@ -122,7 +122,7 @@ if (command === 'auth') {
       console.error('  auth             version          me');
       console.error('  workspace-list');
       console.error(
-        '  track            stop             resume           entry-edit       entry-list       entry-delete'
+        '  track            stop             resume [<id>]    entry-edit       entry-list       entry-delete'
       );
       console.error('  week');
       console.error('  client-list      client-add');

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -68,7 +68,7 @@ describe('resume command', () => {
     });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await resume();
+    await resume([]);
 
     expect(mockedGet).toHaveBeenNthCalledWith(1, '/me/time_entries/current');
     expect(mockedGet).toHaveBeenNthCalledWith(
@@ -101,7 +101,7 @@ describe('resume command', () => {
     mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([runningEntry, stoppedEntry]);
     mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
 
-    await resume();
+    await resume([]);
 
     expect(mockedPost).toHaveBeenCalledWith(
       '/workspaces/123/time_entries',
@@ -119,7 +119,7 @@ describe('resume command', () => {
     ]);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await resume();
+    await resume([]);
 
     expect(errorSpy).toHaveBeenCalledWith('No stopped task found today to resume.');
     expect(mockedPost).not.toHaveBeenCalled();
@@ -139,7 +139,7 @@ describe('resume command', () => {
     mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([lateEntry, earlyEntry]);
     mockedPost.mockResolvedValue({ ...lateEntry, id: 999, stop: null, duration: -1 });
 
-    await resume();
+    await resume([]);
 
     expect(mockedPost).toHaveBeenCalledWith(
       '/workspaces/123/time_entries',
@@ -157,7 +157,7 @@ describe('resume command', () => {
     mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
     mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
 
-    await resume();
+    await resume([]);
 
     expect(mockedPost).toHaveBeenCalledWith(
       '/workspaces/789/time_entries',
@@ -175,7 +175,7 @@ describe('resume command', () => {
     mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
     mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
 
-    await resume();
+    await resume([]);
 
     expect(mockedPost).toHaveBeenCalledWith(
       '/workspaces/123/time_entries',
@@ -188,7 +188,7 @@ describe('resume command', () => {
     mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce([stoppedEntry]);
     mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
 
-    await resume();
+    await resume([]);
 
     expect(mockedPost).toHaveBeenCalledWith(
       '/workspaces/123/time_entries',
@@ -205,7 +205,7 @@ describe('resume command', () => {
       ]);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await resume();
+    await resume([]);
 
     expect(errorSpy).toHaveBeenCalledWith('No stopped task found today to resume.');
     expect(mockedPost).not.toHaveBeenCalled();
@@ -221,7 +221,7 @@ describe('resume command', () => {
     );
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await resume();
+    await resume([]);
 
     expect(errorSpy).toHaveBeenCalledWith(
       `Timer "Current task" is already running. Stop it first with 'tgp stop'.`
@@ -236,8 +236,111 @@ describe('resume command', () => {
     mockedPost.mockResolvedValue({ ...stoppedEntry, id: 999, stop: null, duration: -1 });
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await resume();
+    await resume([]);
 
     expect(logSpy).toHaveBeenCalledWith('Started: (no description) [Dev-Pilot] {dev, bug} (id: 999)');
+  });
+
+  it('resumes a specific entry by id even from a previous day', async () => {
+    const oldEntry = makeEntry({
+      id: 555,
+      description: 'Old task',
+      start: toUtcIso('2025-06-10T09:00:00'),
+      stop: toUtcIso('2025-06-10T10:00:00'),
+      tags: ['legacy'],
+    });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce(oldEntry);
+    mockedPost.mockResolvedValue({ ...oldEntry, id: 999, stop: null, duration: -1 });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await resume(['555']);
+
+    expect(mockedGet).toHaveBeenNthCalledWith(2, '/me/time_entries/555');
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries',
+      expect.objectContaining({
+        description: 'Old task',
+        project_id: 10,
+        tags: ['legacy'],
+        workspace_id: 123,
+        duration: -1,
+      })
+    );
+    expect(logSpy).toHaveBeenCalledWith('Started: Old task [Dev-Pilot] {legacy} (id: 999)');
+  });
+
+  it('prints an error when the id is not found', async () => {
+    mockedGet.mockResolvedValueOnce(null).mockRejectedValueOnce(new Error('Toggl API 404: not found'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await resume(['999999']);
+
+    expect(mockedGet).toHaveBeenNthCalledWith(2, '/me/time_entries/999999');
+    expect(errorSpy).toHaveBeenCalledWith('Time entry 999999 not found.');
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-404 errors instead of masking them as not found', async () => {
+    mockedGet.mockResolvedValueOnce(null).mockRejectedValueOnce(new Error('Toggl API 402: quota exceeded'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(resume(['999999'])).rejects.toThrow('Toggl API 402: quota exceeded');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a still-running entry id', async () => {
+    const running = makeEntry({ id: 555, stop: null, duration: -1 });
+    mockedGet.mockResolvedValueOnce(null).mockResolvedValueOnce(running);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await resume(['555']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Time entry 555 is still running and cannot be resumed. Stop it first with 'tgp stop'.`
+    );
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('still applies the running-timer guard when an id is given', async () => {
+    mockedGet.mockResolvedValueOnce(makeEntry({ description: 'Current task', stop: null, duration: -1 }));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await resume(['555']);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Timer "Current task" is already running. Stop it first with 'tgp stop'.`
+    );
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects unexpected flags', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+      throw new Error(`exit ${code}`);
+    });
+
+    await expect(resume(['--foo'])).rejects.toThrow('exit 1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Usage: tgp resume [<entry_id>]');
+    expect(mockedGet).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('rejects more than one positional argument', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+      throw new Error(`exit ${code}`);
+    });
+
+    await expect(resume(['123', '456'])).rejects.toThrow('exit 1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Usage: tgp resume [<entry_id>]');
+    expect(mockedGet).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #167

## Summary

Adds an optional entry ID to `tgp resume` so any past task can be restarted, not just today's most recent stop.

- `tgp resume` — unchanged: resumes the latest stopped entry from today
- `tgp resume <id>` — fetches that entry via `GET /me/time_entries/{id}` and starts a new running timer with the same description, project, tags, and workspace. The "stopped today" restriction does **not** apply, since the point is to reach back further.

The `<id>` is the value shown in the first column of `tgp entry-list`, matching the convention already used by `tgp entry-edit <id>` and `tgp entry-delete <id>`.

## Guards

- If a timer is already running, prints the existing error and does nothing (applies to both forms)
- If the given ID is still a running entry (`duration < 0`), rejects it with a clear message
- If the ID is unknown (400/404), prints a friendly error
- Non-404 failures (402 quota, 401, 500, network) propagate instead of being masked as "not found" — mirrors the `entry-delete` convention
- Unknown flags / extra positional args → usage error before any API call (quota-safe)

## Changes

- `src/commands/resume.ts` — `resume(args)`; extracted `startFrom`/`printStarted` helpers; added `resumeById` path
- `src/index.ts` — wired `resume(args)`; updated help text to `resume [<id>]`
- `docs/resume.md` — documented both forms and all error messages
- `README.md` — updated resume row to `tgp resume [<id>]`
- `tests/resume.test.ts` — migrated existing tests to `resume([])` and added 7 new cases (resume by ID, not found, running entry rejected, running-timer guard with ID, 402 rethrow, unexpected flags, too many args)

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 318 passed (25 files)
