### PR TITLE
feat: add --start flag to entry-edit to amend start time (#185)

### DIFF
--- a/docs/entry-edit.md
+++ b/docs/entry-edit.md
@@ -1,13 +1,15 @@
 # `entry-edit` — Edit a Time Entry
 
-Edit the description, project, tags, or duration of an existing time entry. Preserves the timer
+Edit the description, project, tags, start time, or duration of an existing time entry. Preserves the timer
 state — running entries stay running, stopped entries stay stopped. When editing duration,
-the start time stays fixed and the end time is recomputed.
+the start time stays fixed and the end time is recomputed. When editing the start time, the
+timer state is preserved: a running entry keeps running from the new start, a stopped entry
+keeps its end time fixed and recomputes the duration.
 
 ## Usage
 
 ```bash
-tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2] [--dur 1h30m]
+tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2] [--dur 1h30m] [--start HH:MM]
 ```
 
 ## Examples
@@ -17,20 +19,34 @@ tgp entry-edit 4383745312 -d "Updated description"
 tgp entry-edit 4383745312 -p "Dev-Pilot"
 tgp entry-edit 4383745312 -t dev,review
 tgp entry-edit 4383745312 --dur 1h30m
+tgp entry-edit 4383745312 --start 11:20
+tgp entry-edit 4383745312 --start 2026-07-14T11:20:00+07:00
 tgp entry-edit 4383745312 -d "Fixed typo" -p "Dev-Pilot" -t dev
 tgp entry-edit 4383745312 -d "Fixed typo" --dur 45m
+tgp entry-edit 4383745312 --start 11:20 --dur 1h30m
 ```
 
 ## Options
 
-| Flag            | Short | Description                              |
-| --------------- | ----- | ---------------------------------------- |
-| `--description` | `-d`  | New description                          |
-| `--project`     | `-p`  | New project name (case-insensitive)      |
-| `--tags`        | `-t`  | New tags (replaces existing)             |
-| `--dur`         |       | New duration (e.g. `1h30m`, `2h`, `45m`) |
+| Flag            | Short | Description                                       |
+| --------------- | ----- | ------------------------------------------------- |
+| `--description` | `-d`  | New description                                   |
+| `--project`     | `-p`  | New project name (case-insensitive)               |
+| `--tags`        | `-t`  | New tags (replaces existing)                      |
+| `--dur`         |       | New duration (e.g. `1h30m`, `2h`, `45m`)          |
+| `--start`       |       | New start time (`HH:MM` today local, or ISO 8601) |
 
 You must provide at least one option. Find the entry ID using `tgp entry-list`.
+
+## Editing the start time
+
+`--start` accepts a bare `HH:MM` (interpreted as today in your local timezone) or a full
+ISO 8601 timestamp (e.g. `2026-07-14T11:20:00+07:00`). Future start times are rejected.
+
+- **Running entry:** the timer keeps running from the new start time.
+- **Stopped entry:** the end time stays fixed and the duration is recomputed. The new start
+  must be before the end time.
+- **`--start` + `--dur` together (stopped entry):** the end time is set to `start + duration`.
 
 ## Output
 

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -1,5 +1,5 @@
 import { get, put } from '../api.js';
-import { parseDuration, parseOrExit, requireFlagValue } from '../utils.js';
+import { parseDuration, parseOrExit, parseStartTime, requireFlagValue } from '../utils.js';
 
 interface TimeEntry {
   id: number;
@@ -30,7 +30,7 @@ interface TimeEntryUpdate {
   tags?: string[];
 }
 
-const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '-d', '--description', '--dur']);
+const VALID_FLAGS = new Set(['-p', '--project', '-t', '--tags', '-d', '--description', '--dur', '--start']);
 
 function normalizeTags(tags: string[] | null): string[] {
   const normalized: string[] = [];
@@ -61,6 +61,7 @@ function buildUpdateBody(
   entry: TimeEntry,
   description: string,
   projectId: number | null,
+  start: string,
   duration: number,
   stop: string | null,
   tags?: string[]
@@ -68,7 +69,7 @@ function buildUpdateBody(
   return {
     description,
     project_id: projectId,
-    start: entry.start,
+    start,
     stop,
     duration,
     workspace_id: entry.workspace_id,
@@ -83,17 +84,19 @@ export function parseArgs(args: string[]): {
   project: string | null;
   tags: string[] | null;
   dur: string | null;
+  start: string | null;
 } {
   let id: string | null = null;
   let description: string | null = null;
   let project: string | null = null;
   let tags: string[] | null = null;
   let dur: string | null = null;
+  let start: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('-') && !VALID_FLAGS.has(args[i])) {
       throw new Error(
-        `Unknown flag: ${args[i]}. Valid flags: -d/--description, -p/--project, -t/--tags, --dur`
+        `Unknown flag: ${args[i]}. Valid flags: -d/--description, -p/--project, -t/--tags, --dur, --start`
       );
     }
 
@@ -109,6 +112,9 @@ export function parseArgs(args: string[]): {
     } else if (args[i] === '--dur') {
       dur = requireFlagValue(args, i, args[i]);
       i++;
+    } else if (args[i] === '--start') {
+      start = requireFlagValue(args, i, args[i]);
+      i++;
     } else if (!args[i].startsWith('-') && !id) {
       id = args[i];
     }
@@ -116,19 +122,26 @@ export function parseArgs(args: string[]): {
 
   if (!id) {
     throw new Error(
-      'Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2] [--dur 1h30m]'
+      'Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2] [--dur 1h30m] [--start HH:MM]'
     );
   }
 
-  if (!description && !project && !tags && !dur) {
-    throw new Error('Nothing to edit. Provide at least one of: -d, -p, -t, --dur');
+  if (!description && !project && !tags && !dur && !start) {
+    throw new Error('Nothing to edit. Provide at least one of: -d, -p, -t, --dur, --start');
   }
 
-  return { id: id!, description, project, tags, dur };
+  return { id: id!, description, project, tags, dur, start };
 }
 
 export async function entryEdit(args: string[]) {
-  const { id, description, project: projectName, tags: newTags, dur } = parseOrExit(() => parseArgs(args));
+  const {
+    id,
+    description,
+    project: projectName,
+    tags: newTags,
+    dur,
+    start: startInput,
+  } = parseOrExit(() => parseArgs(args));
 
   let entry: TimeEntry;
   try {
@@ -158,17 +171,41 @@ export async function entryEdit(args: string[]) {
 
   let newDuration = entry.duration;
   let newStop = entry.stop;
+  let newStartISO = entry.start;
+
+  if (startInput) {
+    // parseStartTime throws on invalid format or future start times.
+    const newStart = parseStartTime(startInput);
+    newStartISO = newStart.toISOString();
+  }
+
   if (dur) {
     if (!entry.stop) {
       console.error('Cannot change duration of a running timer. Stop it first with: tgp stop');
       process.exit(1);
     }
     newDuration = parseDuration(dur);
-    newStop = new Date(new Date(entry.start).getTime() + newDuration * 1000).toISOString();
+    // stop = start + dur; uses the (possibly amended) start.
+    newStop = new Date(new Date(newStartISO).getTime() + newDuration * 1000).toISOString();
+  } else if (startInput) {
+    if (!entry.stop) {
+      // Running entry: keep it running via Toggl's negative-duration convention.
+      newDuration = -Math.floor(new Date(newStartISO).getTime() / 1000);
+      newStop = null;
+    } else {
+      // Stopped entry: keep stop fixed, recompute duration from the new start.
+      const stopEpoch = new Date(entry.stop).getTime();
+      const startEpoch = new Date(newStartISO).getTime();
+      if (startEpoch >= stopEpoch) {
+        console.error('Start time must be before the stop time.');
+        process.exit(1);
+      }
+      newDuration = Math.floor((stopEpoch - startEpoch) / 1000);
+    }
   }
 
   const nextDescription = description ?? entry.description;
-  const hasEntryChanges = description !== null || projectName !== null || dur !== null;
+  const hasEntryChanges = description !== null || projectName !== null || dur !== null || startInput !== null;
   const hasTagChanges =
     newTags !== null &&
     (diffTags(normalizeTags(entry.tags), newTags).length > 0 ||
@@ -183,6 +220,7 @@ export async function entryEdit(args: string[]) {
         entry,
         nextDescription,
         projectId,
+        newStartISO,
         newDuration,
         newStop,
         newTags !== null ? newTags : undefined

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,28 @@ export function buildStartTime(at: string, date?: string): string {
   return d.toISOString();
 }
 
+/**
+ * Parse a start time for entry-edit. Accepts a bare `HH:MM` (today, local tz,
+ * via the shared strict `buildStartTime`) or a full ISO 8601 timestamp.
+ * Rejects times in the future (a near-certain typo, intentionally stricter
+ * than the API). Note: bare-time format relaxation (e.g. `8:20`) lives in
+ * `buildStartTime` and is tracked separately in #186.
+ */
+export function parseStartTime(value: string): Date {
+  const isTimeOfDay = /^\d{1,2}:\d{2}$/.test(value);
+  const iso = isTimeOfDay ? buildStartTime(value) : value;
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) {
+    throw new Error(
+      `Invalid start time: ${value}. Use HH:MM (e.g. 11:20) or ISO 8601 (e.g. 2026-07-14T11:20:00+07:00).`
+    );
+  }
+  if (d.getTime() > Date.now()) {
+    throw new Error(`Start time cannot be in the future: ${value}`);
+  }
+  return d;
+}
+
 export function localYesterdayDate(): Date {
   const d = new Date();
   d.setDate(d.getDate() - 1);

--- a/tests/entry-edit-parseArgs.test.ts
+++ b/tests/entry-edit-parseArgs.test.ts
@@ -10,6 +10,7 @@ describe('entry-edit parseArgs', () => {
       project: null,
       tags: null,
       dur: null,
+      start: null,
     });
   });
 
@@ -42,6 +43,7 @@ describe('entry-edit parseArgs', () => {
       project: 'Project',
       tags: ['review'],
       dur: null,
+      start: null,
     });
   });
 
@@ -123,5 +125,39 @@ describe('entry-edit parseArgs', () => {
 
   it('throws on --dur with empty value', () => {
     expect(() => parseArgs(['12345', '--dur', ''])).toThrow('Missing value for --dur.');
+  });
+
+  it('parses --start', () => {
+    const result = parseArgs(['12345', '--start', '11:20']);
+    expect(result.start).toBe('11:20');
+  });
+
+  it('parses --start with ISO 8601 value', () => {
+    const result = parseArgs(['12345', '--start', '2026-07-14T11:20:00+07:00']);
+    expect(result.start).toBe('2026-07-14T11:20:00+07:00');
+  });
+
+  it('parses --start combined with other flags', () => {
+    const result = parseArgs(['12345', '-d', 'Desc', '--start', '11:20']);
+    expect(result.description).toBe('Desc');
+    expect(result.start).toBe('11:20');
+  });
+
+  it('parses --start and --dur together', () => {
+    const result = parseArgs(['12345', '--start', '11:20', '--dur', '1h30m']);
+    expect(result.start).toBe('11:20');
+    expect(result.dur).toBe('1h30m');
+  });
+
+  it('throws on --start with no value', () => {
+    expect(() => parseArgs(['12345', '--start'])).toThrow('Missing value for --start.');
+  });
+
+  it('throws on --start followed by another flag', () => {
+    expect(() => parseArgs(['12345', '--start', '-d', 'desc'])).toThrow('Missing value for --start.');
+  });
+
+  it('throws on --start with empty value', () => {
+    expect(() => parseArgs(['12345', '--start', ''])).toThrow('Missing value for --start.');
   });
 });

--- a/tests/entry-edit.test.ts
+++ b/tests/entry-edit.test.ts
@@ -208,4 +208,102 @@ describe('entryEdit command', () => {
     exitSpy.mockRestore();
     logSpy.mockRestore();
   });
+
+  it('amends start time of a running timer, keeps it running', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry, stop: null, duration: -1 });
+    mockedPut.mockResolvedValue({ ...baseEntry, stop: null, duration: -1 });
+
+    await entryEdit(['100', '--start', '2025-06-15T09:00:00Z']);
+
+    const expectedStartEpoch = Math.floor(new Date('2025-06-15T09:00:00Z').getTime() / 1000);
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        start: '2025-06-15T09:00:00.000Z',
+        stop: null,
+        // Toggl's negative-duration "running" convention, relative to the new start.
+        duration: -expectedStartEpoch,
+      })
+    );
+  });
+
+  it('amends start time of a stopped entry, recomputes duration keeping stop fixed', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry });
+    mockedPut.mockResolvedValue({ ...baseEntry, duration: 7200 });
+
+    await entryEdit(['100', '--start', '2025-06-15T09:00:00Z']);
+
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        start: '2025-06-15T09:00:00.000Z',
+        stop: '2025-06-15T11:00:00Z',
+        duration: 7200,
+      })
+    );
+  });
+
+  it('combines --start and --dur on a stopped entry: stop = start + dur', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry });
+    mockedPut.mockResolvedValue({ ...baseEntry, duration: 10800, stop: '2025-06-15T12:00:00Z' });
+
+    await entryEdit(['100', '--start', '2025-06-15T09:00:00Z', '--dur', '3h']);
+
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        start: '2025-06-15T09:00:00.000Z',
+        stop: '2025-06-15T12:00:00.000Z',
+        duration: 10800,
+      })
+    );
+  });
+
+  it('rejects --start after the stop time on a stopped entry', async () => {
+    mockedGet.mockResolvedValue({ ...baseEntry });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(entryEdit(['100', '--start', '2025-06-15T12:00:00Z'])).rejects.toThrow('exit');
+
+    expect(logSpy).toHaveBeenCalledWith('Start time must be before the stop time.');
+    expect(mockedPut).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('amends start time using bare HH:MM (today, local tz)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 5, 15, 12, 0, 0));
+    mockedGet.mockResolvedValue({ ...baseEntry, stop: null, duration: -1 });
+    mockedPut.mockResolvedValue({ ...baseEntry, stop: null, duration: -1 });
+
+    await entryEdit(['100', '--start', '09:00']);
+
+    const expectedISO = new Date(2025, 5, 15, 9, 0, 0).toISOString();
+    const expectedDuration = -Math.floor(new Date(expectedISO).getTime() / 1000);
+    expect(mockedPut).toHaveBeenCalledWith(
+      '/workspaces/123/time_entries/100',
+      expect.objectContaining({
+        start: expectedISO,
+        stop: null,
+        duration: expectedDuration,
+      })
+    );
+    vi.useRealTimers();
+  });
+
+  it('rejects future start times', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 5, 15, 12, 0, 0));
+    mockedGet.mockResolvedValue({ ...baseEntry, stop: null, duration: -1 });
+
+    await expect(entryEdit(['100', '--start', '13:00'])).rejects.toThrow('cannot be in the future');
+
+    expect(mockedPut).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatDate,
   formatTime,
   buildStartTime,
+  parseStartTime,
   parseDateArg,
   parseOrExit,
   localYesterdayDate,
@@ -149,6 +150,42 @@ describe('buildStartTime', () => {
     const expected = new Date('2025-06-16T22:00:00').toISOString();
     expect(result).toBe(expected);
     vi.useRealTimers();
+  });
+});
+
+describe('parseStartTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 5, 15, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('parses full ISO 8601 in the past', () => {
+    // Faked now is local 2025-06-15 12:00 (= 05:00Z at +07:00), so use a value
+    // safely before that in any timezone.
+    const result = parseStartTime('2025-06-14T09:00:00Z');
+    expect(result).toEqual(new Date('2025-06-14T09:00:00Z'));
+  });
+
+  it('parses bare HH:MM as today local time', () => {
+    const result = parseStartTime('09:00');
+    expect(result).toEqual(new Date(2025, 5, 15, 9, 0, 0));
+  });
+
+  it('rejects future bare HH:MM start times', () => {
+    // 13:00 is one hour after the faked now (12:00)
+    expect(() => parseStartTime('13:00')).toThrow('cannot be in the future');
+  });
+
+  it('rejects future ISO start times', () => {
+    expect(() => parseStartTime('2030-06-15T09:00:00Z')).toThrow('cannot be in the future');
+  });
+
+  it('rejects invalid format', () => {
+    expect(() => parseStartTime('not-a-time')).toThrow('Invalid start time');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `--start` flag to `entry-edit` that amends an entry's start time while preserving its running/stopped state. Closes #185.

This fills a gap: previously there was no way to change an entry's start time at all (no `--start` flag, and `--dur` both rejects running timers and can't move the start).

## Behavior

- **Running entry:** set new `start`, recompute `duration = -floor(epoch)` (Toggl's negative-duration "running" convention), keep `stop: null`. Timer keeps running from the new start.
- **Stopped entry:** set new `start`, keep `stop` fixed, recompute `duration`. Rejects `start >= stop`.
- **`--start` + `--dur` together (stopped):** `stop = start + dur`.
- **`--dur` on a running entry:** still rejected (unchanged).
- **Input format:** bare `HH:MM` (today, local tz) via the shared strict `buildStartTime`, or full ISO 8601.
- **Future start times** are rejected (intentionally stricter than the API — a near-certain typo). Future stop times remain allowed to mirror the API, consistent with existing `track`/`--dur` behavior.

## Decisions (from #185 discussion)

- `--start` + `--dur` is well-defined (not ambiguous): `stop = start + dur`.
- Friendly `HH:MM` (today, local tz) accepted; strict two-digit form for now.
- Future-start guard kept; future-stop allowed everywhere (mirror API).
- HH:MM relaxation (single-digit hours like `8:20`) is cross-cutting and tracked in #186. `--start` routes through `buildStartTime` so #186 will propagate automatically.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 336 passed (25 files)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint:md` — clean

New tests added:
- `tests/utils.test.ts` — `parseStartTime`: ISO, bare `HH:MM`, future rejection, invalid format
- `tests/entry-edit-parseArgs.test.ts` — `--start` parsing, missing value, combined flags, empty value
- `tests/entry-edit.test.ts` — running keeps running; stopped recomputes duration; `--start`+`--dur` combo; `start >= stop` rejection; bare `HH:MM`; future rejection

## Known limitation

`--start` + `--dur` on a running entry is rejected (because `--dur` on running is rejected). This is intentional per #185. To set both on a running entry, stop it first, then `entry-edit --start ... --dur ...`.

## Out of scope

- #186 — relax `HH:MM` to allow single-digit hours across the CLI.
- Cross-cutting uniform error handling for mid-execution validation throws (pre-existing; `parseDuration` already behaves this way).
