### PR TITLE
feat: relax time parsing to allow single-digit hours and harden ISO validation (#186)

### DIFF
--- a/docs/entry-edit.md
+++ b/docs/entry-edit.md
@@ -9,7 +9,7 @@ keeps its end time fixed and recomputes the duration.
 ## Usage
 
 ```bash
-tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2] [--dur 1h30m] [--start HH:MM]
+tgp entry-edit <entry_id> [-d "New description"] [-p "Project name"] [-t tag1,tag2] [--dur 1h30m] [--start [H]H:MM]
 ```
 
 ## Examples
@@ -28,20 +28,21 @@ tgp entry-edit 4383745312 --start 11:20 --dur 1h30m
 
 ## Options
 
-| Flag            | Short | Description                                       |
-| --------------- | ----- | ------------------------------------------------- |
-| `--description` | `-d`  | New description                                   |
-| `--project`     | `-p`  | New project name (case-insensitive)               |
-| `--tags`        | `-t`  | New tags (replaces existing)                      |
-| `--dur`         |       | New duration (e.g. `1h30m`, `2h`, `45m`)          |
-| `--start`       |       | New start time (`HH:MM` today local, or ISO 8601) |
+| Flag            | Short | Description                                         |
+| --------------- | ----- | --------------------------------------------------- |
+| `--description` | `-d`  | New description                                     |
+| `--project`     | `-p`  | New project name (case-insensitive)                 |
+| `--tags`        | `-t`  | New tags (replaces existing)                        |
+| `--dur`         |       | New duration (e.g. `1h30m`, `2h`, `45m`)            |
+| `--start`       |       | New start time (`[H]H:MM` today local, or ISO 8601) |
 
 You must provide at least one option. Find the entry ID using `tgp entry-list`.
 
 ## Editing the start time
 
-`--start` accepts a bare `HH:MM` (interpreted as today in your local timezone) or a full
-ISO 8601 timestamp (e.g. `2026-07-14T11:20:00+07:00`). Future start times are rejected.
+`--start` accepts a bare `[H]H:MM` (interpreted as today in your local timezone; the minute
+must be two digits, e.g. `8:20` or `09:07`) or a full ISO 8601 timestamp carrying a timezone
+(`Z` or a numeric offset, e.g. `2026-07-14T11:20:00+07:00`). Future start times are rejected.
 
 - **Running entry:** the timer keeps running from the new start time.
 - **Stopped entry:** the end time stays fixed and the duration is recomputed. The new start

--- a/docs/track.md
+++ b/docs/track.md
@@ -5,7 +5,7 @@ Starts a running timer or logs a completed time entry with project and tags.
 ## Usage
 
 ```bash
-tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m] [-d YYYY-MM-DD|yesterday]
+tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at [H]H:MM] [--dur 1h30m] [-d YYYY-MM-DD|yesterday]
 ```
 
 ## Running Timer
@@ -45,7 +45,7 @@ tgp track "Bug fix" -p "Dev-Pilot" --at 14:00 --dur 1h --date 2025-06-05
 | ----------- | ----- | -------------------------------------------------------------- |
 | `--project` | `-p`  | Project name (case-insensitive)                                |
 | `--tags`    | `-t`  | Comma-separated tag names                                      |
-| `--at`      |       | Start time in HH:MM format — requires `--dur`                  |
+| `--at`      |       | Start time as `[H]H:MM` — requires `--dur`                     |
 | `--dur`     |       | Duration (e.g. `30m`, `1h`, `1h30m`) — requires `--at`         |
 | `--date`    | `-d`  | Date (`YYYY-MM-DD` or `yesterday`) — requires `--at` + `--dur` |
 

--- a/src/commands/entry-edit.ts
+++ b/src/commands/entry-edit.ts
@@ -122,7 +122,7 @@ export function parseArgs(args: string[]): {
 
   if (!id) {
     throw new Error(
-      'Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2] [--dur 1h30m] [--start HH:MM]'
+      'Usage: tgp entry-edit <entry_id> [-d "New desc"] [-p "Project"] [-t tag1,tag2] [--dur 1h30m] [--start [H]H:MM]'
     );
   }
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -73,7 +73,7 @@ export function parseArgs(args: string[]): {
 
   if (!description) {
     throw new Error(
-      'Usage: tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at HH:MM] [--dur 1h30m] [-d YYYY-MM-DD|yesterday]'
+      'Usage: tgp track "Description" [-p "Project name"] [-t tag1,tag2] [--at [H]H:MM] [--dur 1h30m] [-d YYYY-MM-DD|yesterday]'
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,24 @@ export function buildStartTime(at: string, date?: string): string {
   if (isNaN(d.getTime())) {
     throw new Error(`Invalid time: ${at}. Use H:MM or HH:MM format (e.g. 8:20, 09:07).`);
   }
+  // Reject DST-normalized wall-clock times. During a spring-forward gap (e.g.
+  // 02:30 on 2025-03-09 in America/New_York) the requested time does not exist,
+  // and the local Date constructor silently shifts it forward instead of
+  // rejecting it. That would record the wrong instant, so compare the
+  // constructed Date's local components against the validated input and reject
+  // any mismatch. `day` is always YYYY-MM-DD from formatDate / track's --date.
+  const [yyyy, mo, dd] = day.split('-').map(Number);
+  if (
+    d.getFullYear() !== yyyy ||
+    d.getMonth() !== mo - 1 ||
+    d.getDate() !== dd ||
+    d.getHours() !== hours ||
+    d.getMinutes() !== minutes
+  ) {
+    throw new Error(
+      `Invalid time: ${at}. ${at} does not exist on ${day} in this timezone (it falls in a DST gap).`
+    );
+  }
   return d.toISOString();
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,32 +43,79 @@ export function formatTime(iso: string): string {
 }
 
 export function buildStartTime(at: string, date?: string): string {
+  // Accept a single-digit hour (e.g. 8:20) but always require a two-digit
+  // minute (matches how digital clocks display time). Validate the grammar and
+  // the hour/minute ranges explicitly so validity is decided here, not by the
+  // permissive JS Date parser (which would accept or normalize values like
+  // `0`, locale strings, or out-of-range components).
+  const match = at.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) {
+    throw new Error(`Invalid time: ${at}. Use H:MM or HH:MM format (e.g. 8:20, 09:07).`);
+  }
+  const hours = parseInt(match[1], 10);
+  const minutes = parseInt(match[2], 10);
+  if (hours > 23 || minutes > 59) {
+    throw new Error(`Invalid time: ${at}. Use H:MM or HH:MM format (e.g. 8:20, 09:07).`);
+  }
   const day = date ?? formatDate(new Date());
-  const d = new Date(`${day}T${at}:00`);
-  if (isNaN(d.getTime())) throw new Error(`Invalid time: ${at}. Use HH:MM format.`);
+  // Normalize to zero-padded HH:MM so the local datetime string is parsed
+  // consistently (the Date string parser rejects single-digit hours). Validity
+  // was already decided above; this only converts a known-good local time.
+  const hh = String(hours).padStart(2, '0');
+  const d = new Date(`${day}T${hh}:${match[2]}:00`);
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid time: ${at}. Use H:MM or HH:MM format (e.g. 8:20, 09:07).`);
+  }
   return d.toISOString();
 }
 
 /**
- * Parse a start time for entry-edit. Accepts a bare `HH:MM` (today, local tz,
- * via the shared strict `buildStartTime`) or a full ISO 8601 timestamp.
- * Rejects times in the future (a near-certain typo, intentionally stricter
- * than the API). Note: bare-time format relaxation (e.g. `8:20`) lives in
- * `buildStartTime` and is tracked separately in #186.
+ * Parse a start time for entry-edit. Accepts a bare local-time `H:MM` or
+ * `HH:MM` (today, local timezone, via the shared `buildStartTime`) or a full
+ * ISO 8601 timestamp that carries an explicit timezone (`Z` or a numeric
+ * offset). Timezone-less datetimes, locale-formatted strings, and bare numbers
+ * are rejected, and impossible calendar dates (e.g. 2025-02-30) are rejected
+ * rather than normalized. Also rejects times in the future (a near-certain
+ * typo, intentionally stricter than the API).
  */
 export function parseStartTime(value: string): Date {
   const isTimeOfDay = /^\d{1,2}:\d{2}$/.test(value);
-  const iso = isTimeOfDay ? buildStartTime(value) : value;
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) {
+  if (!isTimeOfDay) {
+    // Require a full ISO 8601 timestamp with date, time, and timezone so the
+    // permissive Date parser never gets to accept/normalize undocumented input.
+    const invalid = () =>
+      new Error(
+        `Invalid start time: ${value}. Use H:MM (e.g. 11:20) or ISO 8601 (e.g. 2026-07-14T11:20:00+07:00).`
+      );
+    const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})$/);
+    if (!m) throw invalid();
+    const year = +m[1];
+    const month = +m[2];
+    const day = +m[3];
+    const hour = +m[4];
+    const minute = +m[5];
+    const second = +m[6];
+    if (month < 1 || month > 12 || day < 1 || hour > 23 || minute > 59 || second > 59) {
+      throw invalid();
+    }
+    // Reject impossible calendar dates (e.g. 2025-02-30) instead of letting the
+    // Date parser roll them over. Component round-trip via Date.UTC is
+    // timezone-independent, so the check is unambiguous regardless of offset.
+    const cal = new Date(Date.UTC(year, month - 1, day));
+    if (cal.getUTCFullYear() !== year || cal.getUTCMonth() !== month - 1 || cal.getUTCDate() !== day) {
+      throw invalid();
+    }
+  }
+  const parsed = new Date(isTimeOfDay ? buildStartTime(value) : value);
+  if (isNaN(parsed.getTime())) {
     throw new Error(
-      `Invalid start time: ${value}. Use HH:MM (e.g. 11:20) or ISO 8601 (e.g. 2026-07-14T11:20:00+07:00).`
+      `Invalid start time: ${value}. Use H:MM (e.g. 11:20) or ISO 8601 (e.g. 2026-07-14T11:20:00+07:00).`
     );
   }
-  if (d.getTime() > Date.now()) {
+  if (parsed.getTime() > Date.now()) {
     throw new Error(`Start time cannot be in the future: ${value}`);
   }
-  return d;
+  return parsed;
 }
 
 export function localYesterdayDate(): Date {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import {
   formatDuration,
   parseDuration,
@@ -173,6 +173,34 @@ describe('buildStartTime', () => {
     const expected = new Date('2025-06-16T22:00:00').toISOString();
     expect(result).toBe(expected);
     vi.useRealTimers();
+  });
+});
+
+// DST gap handling depends on the process timezone, so run it in an isolated
+// describe block that swaps TZ to a spring-forward zone and restores it after.
+describe('buildStartTime DST gap', () => {
+  const originalTZ = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = 'America/New_York';
+  });
+
+  afterAll(() => {
+    if (originalTZ === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTZ;
+  });
+
+  it('rejects a nonexistent wall-clock time during spring-forward', () => {
+    // 2025-03-09 in America/New_York: clocks jump 02:00 -> 03:00, so 02:30
+    // does not exist. The local Date constructor normalizes it to 03:30; the
+    // round-trip check must reject it rather than record the wrong instant.
+    expect(() => buildStartTime('02:30', '2025-03-09')).toThrow('does not exist');
+  });
+
+  it('accepts a valid time on a spring-forward day (after the gap)', () => {
+    // 03:30 is after the 02:00 -> 03:00 gap and must still be accepted.
+    const result = buildStartTime('03:30', '2025-03-09');
+    expect(result).toBe('2025-03-09T07:30:00.000Z');
   });
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -132,6 +132,29 @@ describe('buildStartTime', () => {
     expect(() => buildStartTime('abc')).toThrow('Invalid time');
   });
 
+  it('accepts a single-digit hour (H:MM)', () => {
+    const result = buildStartTime('8:20');
+    const expected = new Date(2025, 5, 15, 8, 20, 0).toISOString();
+    expect(result).toBe(expected);
+  });
+
+  it('keeps requiring a two-digit minute', () => {
+    expect(() => buildStartTime('9:7')).toThrow('Invalid time');
+    expect(() => buildStartTime('09:7')).toThrow('Invalid time');
+  });
+
+  it('accepts two-digit minutes that look like digital clocks', () => {
+    const result = buildStartTime('9:07');
+    const expected = new Date(2025, 5, 15, 9, 7, 0).toISOString();
+    expect(result).toBe(expected);
+  });
+
+  it('rejects out-of-range hours and minutes', () => {
+    expect(() => buildStartTime('24:00')).toThrow('Invalid time');
+    expect(() => buildStartTime('12:60')).toThrow('Invalid time');
+    expect(() => buildStartTime('99:99')).toThrow('Invalid time');
+  });
+
   it('builds ISO string for a specific date', () => {
     const result = buildStartTime('09:00', '2025-06-10');
     const expected = new Date(2025, 5, 10, 9, 0, 0).toISOString();
@@ -186,6 +209,36 @@ describe('parseStartTime', () => {
 
   it('rejects invalid format', () => {
     expect(() => parseStartTime('not-a-time')).toThrow('Invalid start time');
+  });
+
+  it('parses a bare single-digit-hour local time (H:MM)', () => {
+    const result = parseStartTime('9:07');
+    expect(result).toEqual(new Date(2025, 5, 15, 9, 7, 0));
+  });
+
+  it('accepts a full ISO 8601 timestamp with a numeric offset', () => {
+    const result = parseStartTime('2025-06-14T09:00:00+07:00');
+    expect(result).toEqual(new Date('2025-06-14T09:00:00+07:00'));
+  });
+
+  it('rejects a bare number', () => {
+    expect(() => parseStartTime('0')).toThrow('Invalid start time');
+  });
+
+  it('rejects a date without a time or timezone', () => {
+    expect(() => parseStartTime('2025-06-14')).toThrow('Invalid start time');
+  });
+
+  it('rejects a locale-formatted date', () => {
+    expect(() => parseStartTime('15/06/2025 09:00')).toThrow('Invalid start time');
+  });
+
+  it('rejects a timezone-less datetime', () => {
+    expect(() => parseStartTime('2025-06-15T09:00:00')).toThrow('Invalid start time');
+  });
+
+  it('rejects an impossible calendar date instead of normalizing it', () => {
+    expect(() => parseStartTime('2025-02-30T09:00:00Z')).toThrow('Invalid start time');
   });
 });
 


### PR DESCRIPTION
## Summary

Relaxes `buildStartTime()` to accept a single-digit hour (e.g. `8:20`) while still requiring a two-digit minute (e.g. `9:07`), and hardens time validation so validity is decided explicitly rather than delegated to JavaScript's permissive `Date` parser.

Closes #186.

## Changes

**`buildStartTime()` (`src/utils.ts`)** — the single shared entry point used by `track --at` and `entry-edit --start`:
- Accepts `H:MM` and `HH:MM` (e.g. `8:20`, `09:07`).
- Always requires a two-digit minute (rejects `9:7`, `09:7`).
- Enforces hour 0–23 / minute 0–59 ranges explicitly (rejects `24:00`, `12:60`, `99:99`).
- Validity is decided before `new Date(...)` is ever consulted; the Date constructor now only converts a known-good local datetime to an ISO instant.

**`parseStartTime()` (`src/utils.ts`)** — ISO path hardened:
- Requires a full ISO 8601 timestamp with date, time, and a timezone (`Z` or a numeric offset like `+07:00`).
- Rejects undocumented inputs: bare numbers (`0`), date-only (`2025-06-14`), locale-formatted strings, and timezone-less datetimes (`2025-06-15T09:00:00`).
- Rejects impossible calendar dates (e.g. `2025-02-30`) instead of normalizing them, via a timezone-independent `Date.UTC` round-trip check.

**Docs/usage** — updated `docs/track.md`, `docs/entry-edit.md`, and both commands' usage strings from `HH:MM` to `[H]H:MM`.

## Acceptance criteria

- [x] `buildStartTime()` accepts both `8:20` and `08:20`
- [x] `buildStartTime()` rejects `9:7` and `09:7` with a clear error
- [x] `buildStartTime()` rejects out-of-range values such as `24:00`, `12:60`, and `99:99`
- [x] `parseStartTime()` accepts `H:MM` / `HH:MM` local times and full ISO 8601 timestamps with `Z` or a numeric offset
- [x] `parseStartTime()` rejects undocumented inputs such as `0`, `2025-06-14`, locale-formatted dates, and timezone-less date-times
- [x] `parseStartTime()` rejects impossible calendar dates such as `2025-02-30T09:00:00Z` instead of normalizing them
- [x] No command parses time formats outside the shared helpers or passes raw user input directly to `new Date(...)` (see note below)
- [x] Unit tests in `tests/utils.test.ts` cover the accepted/rejected time matrix and the ISO regression cases
- [x] `npm run typecheck && npm test && npm run lint && npm run format:check` pass (347 tests)

## Verification

`npm run typecheck && npm test && npm run lint && npm run lint:md && npm run format:check` — all green (347 tests, 25 files).

## Notes / out of scope

- `parseDateArg` (`-d/--date`) still feeds raw input to `new Date(...)`, but that is **date** parsing, and #186 explicitly marks date-format relaxation out of scope. Left untouched.
- The strict ISO regex requires a colon in numeric offsets (`+07:00`); the colon-less form (`+0700`) is rejected. This matches the documented example in the issue and keeps the parser strict, which is the goal here.
