### PR TITLE
feat: support relative day offsets (#194)

### DIFF
--- a/docs/entry-list.md
+++ b/docs/entry-list.md
@@ -7,9 +7,16 @@ Lists all time entries for a given day with totals by project.
 ```bash
 tgp entry-list                        # today
 tgp entry-list -d yesterday           # yesterday
+tgp entry-list -d -2                  # two days ago
+tgp entry-list --date 3               # three days from today
 tgp entry-list -d 2026-04-29          # specific date
 tgp entry-list --date 2026-04-29      # long form
 ```
+
+`--date` (or `-d`) accepts an ISO date, `yesterday`, or an integer day offset from
+today. Negative offsets select past dates, `0` selects today, and positive offsets
+select future dates. Relative values use the local calendar date, so they remain
+correct across daylight-saving and month or year boundaries.
 
 ## Output
 

--- a/docs/week.md
+++ b/docs/week.md
@@ -10,19 +10,22 @@ tgp week --week -1           # last week
 tgp week --week -3           # 3 weeks ago
 tgp week --date 2026-04-01   # week containing Apr 1
 tgp week -d yesterday        # week containing yesterday
+tgp week --date -2           # week containing the date two days ago
 tgp week --verbose           # current week with daily breakdown
 tgp week -v --week -1        # last week with daily breakdown
 ```
 
 ### Flags
 
-| Flag                | Shorthand       | Description                                                        |
-| ------------------- | --------------- | ------------------------------------------------------------------ |
-| `--week N`          | `-w N`          | Relative week offset (0 = current, -1 = last, 2 = two weeks ahead) |
-| `--date YYYY-MM-DD` | `-d YYYY-MM-DD` | Show the week containing the given date (also accepts `yesterday`) |
-| `--verbose`         | `-v`            | Show a per-day breakdown matrix for each project                   |
+| Flag        | Shorthand | Description                                                                               |
+| ----------- | --------- | ----------------------------------------------------------------------------------------- |
+| `--week N`  | `-w N`    | Relative week offset (0 = current, -1 = last, 2 = two weeks ahead)                        |
+| `--date D`  | `-d D`    | Week containing ISO date `D`, `yesterday`, or integer day offset (negative past, 0 today) |
+| `--verbose` | `-v`      | Show a per-day breakdown matrix for each project                                          |
 
 `--date` and `--week` are mutually exclusive. `--verbose` can be combined with either.
+Positive `--date` offsets select future local calendar dates, matching the signed-offset
+behavior of `--week`.
 
 ## Output
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,11 +136,17 @@ export function parseStartTime(value: string): Date {
   return parsed;
 }
 
-export function localYesterdayDate(): Date {
+export function localDateWithOffset(offsetDays: number): Date {
   const d = new Date();
-  d.setDate(d.getDate() - 1);
+  // Calendar arithmetic preserves the requested local day across DST changes;
+  // noon avoids unstable date formatting around midnight transitions.
+  d.setDate(d.getDate() + offsetDays);
   d.setHours(12, 0, 0, 0);
   return d;
+}
+
+export function localYesterdayDate(): Date {
+  return localDateWithOffset(-1);
 }
 
 export function requireFlagValue(
@@ -164,11 +170,24 @@ export function parseDateArg(args: string[]): Date {
   const idx = args.indexOf('-d') !== -1 ? args.indexOf('-d') : args.indexOf('--date');
   if (idx !== -1) {
     const flag = args[idx];
-    const val = requireFlagValue(args, idx, flag, { hint: 'Use YYYY-MM-DD or "yesterday".' });
+    const candidate = args[idx + 1];
+    const val =
+      candidate !== undefined && /^-\d/.test(candidate)
+        ? candidate
+        : requireFlagValue(args, idx, flag, {
+            hint: 'Use YYYY-MM-DD, "yesterday", or an integer day offset (e.g. -2).',
+          });
     if (val === 'yesterday') return localYesterdayDate();
+    if (/^[+-]?\d+$/.test(val)) {
+      const offsetDays = Number(val);
+      if (Number.isSafeInteger(offsetDays)) {
+        const date = localDateWithOffset(offsetDays);
+        if (!isNaN(date.getTime())) return date;
+      }
+    }
     const d = new Date(val + 'T12:00:00');
     if (!isNaN(d.getTime())) return d;
-    throw new Error(`Invalid date: ${val}. Use YYYY-MM-DD or "yesterday".`);
+    throw new Error(`Invalid date: ${val}. Use YYYY-MM-DD, "yesterday", or an integer day offset (e.g. -2).`);
   }
   return new Date();
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -8,6 +8,7 @@ import {
   parseStartTime,
   parseDateArg,
   parseOrExit,
+  localDateWithOffset,
   localYesterdayDate,
   requireFlagValue,
 } from '../src/utils.js';
@@ -307,8 +308,63 @@ describe('parseDateArg', () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    ['0', '2025-06-15'],
+    ['-1', '2025-06-14'],
+    ['-3', '2025-06-12'],
+    ['2', '2025-06-17'],
+    ['+2', '2025-06-17'],
+  ])('parses %s as a relative day offset', (offset, expected) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T00:30:00'));
+    const result = parseDateArg(['--date', offset]);
+    expect(formatDate(result)).toBe(expected);
+    expect(result.getHours()).toBe(12);
+    vi.useRealTimers();
+  });
+
+  it('resolves offsets across a year boundary', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T12:00:00'));
+    expect(formatDate(parseDateArg(['-d', '-3']))).toBe('2025-12-30');
+    vi.useRealTimers();
+  });
+
+  it('resolves offsets across a leap day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-03-01T12:00:00'));
+    expect(formatDate(parseDateArg(['-d', '-1']))).toBe('2024-02-29');
+    vi.useRealTimers();
+  });
+
+  it.each(['-1.5', '1.5', '-2days', '9007199254740992'])('rejects invalid offset %s', (offset) => {
+    expect(() => parseDateArg(['-d', offset])).toThrow('Invalid date');
+  });
+
   it('throws on invalid date', () => {
     expect(() => parseDateArg(['-d', 'not-a-date'])).toThrow('Invalid date');
+  });
+});
+
+describe('localDateWithOffset across DST', () => {
+  const originalTZ = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = 'America/New_York';
+  });
+
+  afterAll(() => {
+    if (originalTZ === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTZ;
+  });
+
+  it('uses local calendar arithmetic across spring-forward', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-03-10T00:30:00-04:00'));
+    const result = localDateWithOffset(-1);
+    expect(formatDate(result)).toBe('2025-03-09');
+    expect(result.getHours()).toBe(12);
+    vi.useRealTimers();
   });
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -358,9 +358,13 @@ describe('localDateWithOffset across DST', () => {
     else process.env.TZ = originalTZ;
   });
 
-  it('uses local calendar arithmetic across spring-forward', () => {
+  it('preserves the calendar day across spring-forward', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-03-10T00:30:00-04:00'));
+
+    expect(new Date().getTimezoneOffset()).toBe(240);
+    expect(formatDate(new Date(Date.now() - 86400000))).toBe('2025-03-08');
+
     const result = localDateWithOffset(-1);
     expect(formatDate(result)).toBe('2025-03-09');
     expect(result.getHours()).toBe(12);

--- a/tests/week.test.ts
+++ b/tests/week.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   getWeekBounds,
   parseWeekArgs,
@@ -84,6 +84,16 @@ describe('parseWeekArgs', () => {
     const { refDate } = parseWeekArgs(['-d', '2026-04-01']);
     const { monday } = getWeekBounds(refDate);
     expect(formatDate(monday)).toBe('2026-03-30');
+  });
+
+  it('parses a relative day offset with --date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-01T12:00:00'));
+    const { refDate } = parseWeekArgs(['--date', '-2']);
+    const { monday } = getWeekBounds(refDate);
+    expect(formatDate(refDate)).toBe('2026-03-30');
+    expect(formatDate(monday)).toBe('2026-03-30');
+    vi.useRealTimers();
   });
 
   it('parses --week -1 (last week)', () => {


### PR DESCRIPTION
## Summary

- accept signed integer day offsets in the shared `-d` / `--date` parser used by `entry-list` and `week`
- preserve ISO dates and the `yesterday` alias while using local calendar arithmetic across DST and calendar boundaries
- document the new syntax and add coverage for valid, invalid, boundary, and integration cases

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (25 files, 362 tests)
- `npm run lint:md`
- `git diff --check`

Closes #194
